### PR TITLE
Element switches

### DIFF
--- a/INCHI-1-SRC/INCHI_BASE/src/ichi_bns.c
+++ b/INCHI-1-SRC/INCHI_BASE/src/ichi_bns.c
@@ -2805,65 +2805,31 @@ int fix_explicitly_indicated_bonds( int nebend,
 /****************************************************************************/
 int is_Z_atom( U_CHAR el_number )
 {
-    enum tag_Z_elnumber
+    switch ( el_number ) 
     {
-        el_C,
-        el_N,
-        el_P,
-        el_As,
-        el_Sb,
-        el_S,
-        el_Se,
-        el_Te,
-        el_Cl,
-        el_Br,
-        el_I,
-#if ( ALL_NONMETAL_Z == 1 )
-        el_B,
-        el_O,
-        el_Si,
-        el_Ge,
-        el_F,
-        el_At,
-#endif
-        el_len
-    }; /* djb-rwth: removing redundant typedef name */
-
-    static U_CHAR el_numb[el_len];
-
-    /*
-    return is_el_a_metal( (int)el_number );
-    */
-
-    if (!el_numb[el_C])
-    {
-        el_numb[el_C] = EL_NUMBER_C;
-        el_numb[el_N] = EL_NUMBER_N;
-        el_numb[el_P] = EL_NUMBER_P;
-        el_numb[el_As] = EL_NUMBER_AS;
-        el_numb[el_Sb] = EL_NUMBER_SB;
-        el_numb[el_S] = EL_NUMBER_S;
-        el_numb[el_Se] = EL_NUMBER_SE;
-        el_numb[el_Te] = EL_NUMBER_TE;
-        el_numb[el_Cl] = EL_NUMBER_CL;
-        el_numb[el_Br] = EL_NUMBER_BR;
-        el_numb[el_I] = EL_NUMBER_I;
-#if ( ALL_NONMETAL_Z == 1 )
-        el_numb[el_B] = EL_NUMBER_B;
-        el_numb[el_O] = EL_NUMBER_O;
-        el_numb[el_Si] = EL_NUMBER_SI;
-        el_numb[el_Ge] = EL_NUMBER_GE;
-        el_numb[el_F] = EL_NUMBER_F;
-        el_numb[el_At] = EL_NUMBER_AT;
-#endif
+        case EL_NUMBER_C: /* fallthrough */
+        case EL_NUMBER_N:
+        case EL_NUMBER_P:
+        case EL_NUMBER_AS:
+        case EL_NUMBER_SB:
+        case EL_NUMBER_S:
+        case EL_NUMBER_SE:
+        case EL_NUMBER_TE:
+        case EL_NUMBER_CL:
+        case EL_NUMBER_BR:
+        case EL_NUMBER_I:
+#if ( ALL_NONMETAL_Z == 1 )        
+        case EL_NUMBER_B:
+        case EL_NUMBER_O:
+        case EL_NUMBER_SI:
+        case EL_NUMBER_GE:
+        case EL_NUMBER_F:
+        case EL_NUMBER_AT:
+#endif        
+            return 1;
+        default:
+            return 0;    
     }
-
-    if (memchr( el_numb, el_number, el_len ))
-    {
-        return 1;
-    }
-
-    return 0;
 }
 
 

--- a/INCHI-1-SRC/INCHI_BASE/src/ichitaut.c
+++ b/INCHI-1-SRC/INCHI_BASE/src/ichitaut.c
@@ -157,35 +157,22 @@ is_centerpoint... functions
 /****************************************************************************/
 int is_centerpoint_elem( U_CHAR el_number )
 {
-    static U_CHAR el_numb[12];
-    static int len;
-    int len2;
-    int i;
-    if (!len)
-    {
-        len2 = 0;
-        el_numb[len2++] = EL_NUMBER_C;
-        el_numb[len2++] = EL_NUMBER_N;
-        el_numb[len2++] = EL_NUMBER_P;
-        el_numb[len2++] = EL_NUMBER_S;
-        el_numb[len2++] = EL_NUMBER_I;
-        el_numb[len2++] = EL_NUMBER_AS;
-        el_numb[len2++] = EL_NUMBER_SB;
-        el_numb[len2++] = EL_NUMBER_SE;
-        el_numb[len2++] = EL_NUMBER_TE;
-        el_numb[len2++] = EL_NUMBER_CL;
-        el_numb[len2++] = EL_NUMBER_BR;
-        len = len2;
-    }
-    for (i = 0; i < len; i++)
-    {
-        if (el_numb[i] == el_number)
-        {
+    switch (el_number) {
+        case EL_NUMBER_C: 
+        case EL_NUMBER_N: 
+        case EL_NUMBER_P: 
+        case EL_NUMBER_S: 
+        case EL_NUMBER_I: 
+        case EL_NUMBER_AS: 
+        case EL_NUMBER_SB: 
+        case EL_NUMBER_SE: 
+        case EL_NUMBER_TE: 
+        case EL_NUMBER_CL:
+        case EL_NUMBER_BR:
             return 1;
-        }
+        default:
+            return 0; 
     }
-
-    return 0;
 }
 
 
@@ -195,22 +182,7 @@ int is_centerpoint_elem( U_CHAR el_number )
 /****************************************************************************/
 int is_centerpoint_elem_KET( U_CHAR el_number )
 {
-    static U_CHAR el_numb[1];
-    static int len;
-    int i;
-    if (!el_numb[0] && !len)
-    {
-        el_numb[len++] = EL_NUMBER_C;
-    }
-    for (i = 0; i < len; i++)
-    {
-        if (el_numb[i] == el_number)
-        {
-            return 1;
-        }
-    }
-
-    return 0;
+    return el_number == EL_NUMBER_C;
 }
 #endif
 
@@ -218,28 +190,16 @@ int is_centerpoint_elem_KET( U_CHAR el_number )
 /****************************************************************************/
 int is_centerpoint_elem_strict( U_CHAR el_number )
 {
-    static U_CHAR el_numb[6];
-    static int len;
-    int len2;
-    int i;
-    if (!len)
-    {
-        len2 = 0;
-        el_numb[len2++] = EL_NUMBER_C;
-        el_numb[len2++] = EL_NUMBER_N;
-        el_numb[len2++] = EL_NUMBER_P;
-        el_numb[len2++] = EL_NUMBER_AS;
-        el_numb[len2++] = EL_NUMBER_SB;
-        len = len2;
-    }
-    for (i = 0; i < len; i++)
-    {
-        if (el_numb[i] == el_number)
-        {
+    switch (el_number) {
+        case EL_NUMBER_C: 
+        case EL_NUMBER_N: 
+        case EL_NUMBER_P: 
+        case EL_NUMBER_AS: 
+        case EL_NUMBER_SB: 
             return 1;
-        }
+        default:
+            return 0; 
     }
-    return 0;
 }
 
 
@@ -570,8 +530,7 @@ int nGetEndpointInfo_PT_16_00(inp_ATOM *atom, int iat, ENDPOINT_INFO *eif)
 
     if (atom[iat].radical && atom[iat].radical != RADICAL_SINGLET)
         return 0; /* a radical */
-    nEndpointValence = atom[iat].el_number == EL_NUMBER_C ? 4 :
-        atom[iat].el_number == EL_NUMBER_O ? 2 : 0;
+    nEndpointValence = get_endpoint_valence_KET( atom[iat].el_number );
     if (!nEndpointValence)
         return 0; /* not an endpoint */
     if (nEndpointValence <= atom[iat].valence)
@@ -648,11 +607,7 @@ int nGetEndpointInfo_PT_06_00(inp_ATOM *atom, int iat, ENDPOINT_INFO *eif)
     if (atom[iat].radical && atom[iat].radical != RADICAL_SINGLET)
         return 0; /* a radical */
     nEndpointValence = atom[iat].el_number == EL_NUMBER_C ? 4 :
-        atom[iat].el_number == EL_NUMBER_N ? 3 :
-        atom[iat].el_number == EL_NUMBER_S ? 2 :
-        atom[iat].el_number == EL_NUMBER_O ? 2 :
-        atom[iat].el_number == EL_NUMBER_SE ? 2 :
-        atom[iat].el_number == EL_NUMBER_TE ? 2 : 0;
+        get_endpoint_valence( atom[iat].el_number );
     /*printf("Connectivity: %d\n", atom[iat].valence);
     printf("Charge: %d\n", atom[iat].charge);
     printf("Actual valence: %d\n", atom[iat].chem_bonds_valence);

--- a/INCHI-1-SRC/INCHI_BASE/src/strutil.c
+++ b/INCHI-1-SRC/INCHI_BASE/src/strutil.c
@@ -124,7 +124,7 @@ int DisconnectAmmoniumSalt( inp_ATOM *at,
 /*int bIsMetalSalt( inp_ATOM *at, int i ); - moved to strutil,h */
 int DisconnectMetalSalt( inp_ATOM *at, int i );
 int bIsMetalToDisconnect( inp_ATOM *at, int i, int bCheckMetalValence );
-int get_iat_number( int el_number, const int el_num[], int el_num_len );
+int get_iat_number( int el_number );
 int tot_unsat( int unsat[] );
 int max_unsat( int unsat[] );
 double dist3D( inp_ATOM *at1, inp_ATOM *at2 );
@@ -612,7 +612,7 @@ int fix_odd_things( int num_atoms,
         EL_NUMBER_N,
         EL_NUMBER_P,
         EL_NUMBER_AS,
-        EL_NUMBER_SB, 
+        EL_NUMBER_SB,
         EL_NUMBER_O,
         EL_NUMBER_S,
         EL_NUMBER_SE,
@@ -4019,23 +4019,6 @@ exit_function:
 }
 
 
-
-/****************************************************************************/
-int get_iat_number( int el_number, const int el_num[], int el_num_len )
-{
-    int i;
-    for (i = 0; i < el_num_len; i++)
-    {
-        if (el_num[i] == el_number)
-        {
-            return i;
-        }
-    }
-
-    return -1;
-}
-
-
 /*#endif*/ /* } DISCONNECT_SALTS */
 
 typedef enum tagIonAtomType
@@ -4052,10 +4035,28 @@ typedef enum tagIonAtomType
     IAT_Cl,
     IAT_Br,
     IAT_I,
-    IAT_MAX
+    IAT_MAX = 12
 } ION_ATOM_TYPE;
 
-
+/****************************************************************************/
+int get_iat_number( int el_number )
+{
+    switch (el_number) {
+        case EL_NUMBER_H:  return IAT_H;
+        case EL_NUMBER_C:  return IAT_C;
+        case EL_NUMBER_N:  return IAT_N;
+        case EL_NUMBER_P:  return IAT_P;
+        case EL_NUMBER_O:  return IAT_O;
+        case EL_NUMBER_S:  return IAT_S;
+        case EL_NUMBER_SE: return IAT_Se;
+        case EL_NUMBER_TE: return IAT_Te;
+        case EL_NUMBER_F:  return IAT_F;
+        case EL_NUMBER_CL: return IAT_Cl;
+        case EL_NUMBER_BR: return IAT_Br;
+        case EL_NUMBER_I:  return IAT_I;
+        default: return -1;
+    }
+}
 
 #if ( READ_INCHI_STRING == 1 )
 
@@ -4064,26 +4065,9 @@ typedef enum tagIonAtomType
 int bHeteroAtomMayHaveXchgIsoH( inp_ATOM *atom, int iat )
 {
     inp_ATOM *at = atom + iat, *at2;
-    static int el_num[IAT_MAX];
     int j, val, is_H = 0, num_H, iat_numb, bAccept; /* djb-rwth: removing redundant variables */
 
-    if (!el_num[IAT_H])
-    {
-        el_num[IAT_H] = EL_NUMBER_H;
-        el_num[IAT_C] = EL_NUMBER_C;
-        el_num[IAT_N] = EL_NUMBER_N;
-        el_num[IAT_P] = EL_NUMBER_P;
-        el_num[IAT_O] = EL_NUMBER_O;
-        el_num[IAT_S] = EL_NUMBER_S;
-        el_num[IAT_Se] = EL_NUMBER_SE;
-        el_num[IAT_Te] = EL_NUMBER_TE;
-        el_num[IAT_F] = EL_NUMBER_F;
-        el_num[IAT_Cl] = EL_NUMBER_CL;
-        el_num[IAT_Br] = EL_NUMBER_BR;
-        el_num[IAT_I] = EL_NUMBER_I;
-    }
-
-    if (0 > ( iat_numb = get_iat_number( at->el_number, el_num, IAT_MAX ) ))
+    if (0 > ( iat_numb = get_iat_number( at->el_number ) ))
     {
         return 0;
     }
@@ -4166,26 +4150,8 @@ int bHeteroAtomMayHaveXchgIsoH( inp_ATOM *atom, int iat )
 /****************************************************************************/
 int bNumHeterAtomHasIsotopicH( inp_ATOM *atom, int num_atoms )
 {
-    static int el_num[IAT_MAX];
     int i, j, val, is_H = 0, num_H, iat_numb, bAccept, num_iso_H, cur_num_iso_H, num_iso_atoms; /* djb-rwth: removing redundant variables */
     inp_ATOM *at, *at2;
-
-    /* one time initialization */
-    if (!el_num[IAT_H])
-    {
-        el_num[IAT_H] = EL_NUMBER_H;
-        el_num[IAT_C] = EL_NUMBER_C;
-        el_num[IAT_N] = EL_NUMBER_N;
-        el_num[IAT_P] = EL_NUMBER_P;
-        el_num[IAT_O] = EL_NUMBER_O;
-        el_num[IAT_S] = EL_NUMBER_S;
-        el_num[IAT_Se] = EL_NUMBER_SE;
-        el_num[IAT_Te] = EL_NUMBER_TE;
-        el_num[IAT_F] = EL_NUMBER_F;
-        el_num[IAT_Cl] = EL_NUMBER_CL;
-        el_num[IAT_Br] = EL_NUMBER_BR;
-        el_num[IAT_I] = EL_NUMBER_I;
-    }
 
     num_iso_H = 0;
     num_iso_atoms = 0;
@@ -4196,7 +4162,7 @@ int bNumHeterAtomHasIsotopicH( inp_ATOM *atom, int num_atoms )
         num_iso_atoms += ( at->iso_atw_diff != 0 || NUM_ISO_H( at, 0 ) );
         /* isotopic atoms and implicit isotopic H */
 
-        if (0 >( iat_numb = get_iat_number( at->el_number, el_num, IAT_MAX ) ))
+        if (0 >( iat_numb = get_iat_number( at->el_number ) ))
         {
             continue;
         }
@@ -4270,7 +4236,7 @@ int bNumHeterAtomHasIsotopicH( inp_ATOM *atom, int num_atoms )
                     bAccept = 0; /* adjacent charged/radical atoms: do not neutralizate */
                     break;
                 }
-                else if (at2->el_number == el_num[IAT_H] &&
+                else if (at2->el_number == EL_NUMBER_H &&
                           at2->valence == 1 && at2->iso_atw_diff)
                 {
                     cur_num_iso_H++; /* isotopic explicit H */
@@ -5112,7 +5078,7 @@ Lt-wt subgraph
  Establish light-weight subgraph representing (part of) orig_inp_data
  ****************************************************************************/
 subgraf *subgraf_new( ORIG_ATOM_DATA *orig_inp_data,
-                      int nnodes, 
+                      int nnodes,
                       int *nodes )
 {
     int i, j, iat, nbr, jat, nj, degree, nat, err = 0;
@@ -5320,7 +5286,7 @@ void subgraf_pathfinder_free( subgraf_pathfinder *spf )
  and fill bonds[nbonds] and atoms[natoms]
  Do not traverse through supplied forbidden edges (if not zero/NULL)
 ****************************************************************************/
-void subgraf_pathfinder_run( subgraf_pathfinder *spf, 
+void subgraf_pathfinder_run( subgraf_pathfinder *spf,
                              int nforbidden,		/* number of edges forbidden for traversal	*/
                              int *forbidden,		/* nodes of forbidden edges: [edge1node1,edge1node2, edge2node1, edge2node2, ... ] */
                              int *nbonds,
@@ -5428,9 +5394,9 @@ void subgraf_pathfinder_run( subgraf_pathfinder *spf,
 
 /****************************************************************************/
 void add_bond_if_unseen( subgraf_pathfinder *spf,
-                         int node0, 
+                         int node0,
                          int node,
-                         int *nbonds, 
+                         int *nbonds,
                          int **bonds )
 {
     int seen, p, at1, at2;
@@ -5469,7 +5435,7 @@ void add_bond_if_unseen( subgraf_pathfinder *spf,
 /****************************************************************************
  At the first call, push start node to spf->start and set spf->nseen = 0
 ****************************************************************************/
-int subgraf_pathfinder_collect_all(subgraf_pathfinder *spf, 
+int subgraf_pathfinder_collect_all(subgraf_pathfinder *spf,
                                    int nforbidden,		/* number of edges forbidden for traversal	*/
                                    int *forbidden,		/* nodes of forbidden edges: [edge1node1,edge1node2, edge2node1, edge2node2, ... ] */
                                    int *atnums          /* 1-based origs# */

--- a/INCHI-1-SRC/INCHI_BASE/src/strutil.c
+++ b/INCHI-1-SRC/INCHI_BASE/src/strutil.c
@@ -607,7 +607,7 @@ int fix_odd_things( int num_atoms,
                     int bFixBug,
                     int bFixNonUniformDraw )
 {
-    // N;P;As;Sb;O;S;Se;Te;C;Si
+    /* N;P;As;Sb;O;S;Se;Te;C;Si */
     static U_CHAR en[] = {
         EL_NUMBER_N,
         EL_NUMBER_P,
@@ -1047,7 +1047,7 @@ the bonds are fixed in fix_special_bonds()
 int remove_ion_pairs( int num_atoms, inp_ATOM *at )
 {
     int num_changes = 0;
-    // N;P;As;Sb;O;S;Se;Te;C;Si?
+    /* N;P;As;Sb;O;S;Se;Te;C;Si? */
     static char en[] = {
         EL_NUMBER_N,
         EL_NUMBER_P,

--- a/INCHI-1-SRC/INCHI_BASE/src/strutil.c
+++ b/INCHI-1-SRC/INCHI_BASE/src/strutil.c
@@ -608,23 +608,20 @@ int fix_odd_things( int num_atoms,
                     int bFixNonUniformDraw )
 {
     /* N;P;As;Sb;O;S;Se;Te;C;Si */
-    static U_CHAR en[] = {
+    static const U_CHAR en[] = {
         EL_NUMBER_N,
         EL_NUMBER_P,
         EL_NUMBER_AS,
-        EL_NUMBER_SB,
+        EL_NUMBER_SB, 
         EL_NUMBER_O,
         EL_NUMBER_S,
         EL_NUMBER_SE,
-        EL_NUMBER_TE,
-        EL_NUMBER_C,
-        EL_NUMBER_SI
+        EL_NUMBER_TE
     };
     static int ne = sizeof(en)/sizeof(en[0]);
 
 #define FIRST_NEIGHB2  4
 #define FIRST_CENTER2  5
-#define NUM_CENTERS_N  4
 
     int i1, i2, k1, k2, c = -1, num_changes = 0;
     char elname[ATOM_EL_LEN];

--- a/INCHI-1-SRC/INCHI_BASE/src/util.c
+++ b/INCHI-1-SRC/INCHI_BASE/src/util.c
@@ -364,7 +364,7 @@ int el_number_in_internal_ref_table( const char* elname )
 int get_periodic_table_number( const char* elname )
 {
     int num;
-    // the single letter (common) elements
+    /* the single letter (common) elements */
     if (!elname[1]) {
         switch (elname[0]) {
             case 'H': return EL_NUMBER_H; break;

--- a/INCHI-1-SRC/INCHI_BASE/src/util.c
+++ b/INCHI-1-SRC/INCHI_BASE/src/util.c
@@ -1454,31 +1454,15 @@ int MakeRemovedProtonsString( int nNumRemovedProtons,
 
 /****************************************************************************/
 int get_endpoint_valence( U_CHAR el_number )
-{
-    static U_CHAR el_numb[6];
-    static int len, len2;
-    int i;
-    int len3;
-    if (!len)
-    {
-        len3 = 0;
-        el_numb[len3++] = EL_NUMBER_O;
-        el_numb[len3++] = EL_NUMBER_S;
-        el_numb[len3++] = EL_NUMBER_SE;
-        el_numb[len3++] = EL_NUMBER_TE;
-        len2 = len3;
-        el_numb[len3++] = EL_NUMBER_N;
-        len = len3;
+{   
+    switch (el_number) {
+        case EL_NUMBER_O:  /* fallthrough */
+        case EL_NUMBER_S:  
+        case EL_NUMBER_SE: 
+        case EL_NUMBER_TE: return 2;
+        case EL_NUMBER_N:  return 3;
+        default: return 0;
     }
-    for (i = 0; i < len; i++)
-    {
-        if (el_numb[i] == el_number)
-        {
-            return i < len2 ? 2 : 3;
-        }
-    }
-
-    return 0;
 }
 
 
@@ -1488,29 +1472,11 @@ int get_endpoint_valence( U_CHAR el_number )
 /****************************************************************************/
 int get_endpoint_valence_KET( U_CHAR el_number )
 {
-    static U_CHAR el_numb[2];
-    static int len, len2;
-    int len3;
-    int i;
-
-    if (!len)
-    {
-        len3 = 0;
-        el_numb[len3++] = EL_NUMBER_O;
-        len2 = len3;
-        el_numb[len3++] = EL_NUMBER_C;
-        len = len3;
+    switch (el_number) {
+        case EL_NUMBER_C: return 4;
+        case EL_NUMBER_O: return 2;
+        default: return 0;
     }
-
-    for (i = 0; i < len; i++)
-    {
-        if (el_numb[i] == el_number)
-        {
-            return i < len2 ? 2 : 4;
-        }
-    }
-
-    return 0;
 }
 #endif
 


### PR DESCRIPTION
- Use /* */ comments - my bad on this one
- Fix a mistake in strutil.c I made, the existing table initialisation was a bit confusing as there were multiple lengths but only the shortest was used. Reading the comments about Y and Z atoms makes it clearer.
- Many linear table lookups can (should) be replaced with switches on the atomic number. These are the simple ones, ``is_centerpoint_elem_KET()`` is a nice example.
 
There are a few more in strutil/ichi_bns but needs explanation of what was going on so will do those separately. 