### PR TITLE
Replace memchr() check with a new function to check the element group.

### DIFF
--- a/INCHI-1-SRC/INCHI_BASE/src/strutil.c
+++ b/INCHI-1-SRC/INCHI_BASE/src/strutil.c
@@ -1044,30 +1044,6 @@ the bonds are fixed in fix_special_bonds()
 int remove_ion_pairs( int num_atoms, inp_ATOM *at )
 {
     int num_changes = 0;
-    /* N;P;As;Sb;O;S;Se;Te;C;Si? */
-    static char en[] = {
-        EL_NUMBER_N,
-        EL_NUMBER_P,
-        EL_NUMBER_AS,
-        EL_NUMBER_SB,
-        EL_NUMBER_O,
-        EL_NUMBER_S,
-        EL_NUMBER_SE,
-        EL_NUMBER_TE,
-        EL_NUMBER_C
-#if ( FIX_REM_ION_PAIRS_Si_BUG == 1 )        
-        ,EL_NUMBER_SI
-#endif        
-    };
-    static int ne = sizeof(en)/sizeof(en[0]);
-
-#define ELEM_N_FST  0
-#define ELEM_N_LEN  4
-#define ELEM_O_FST  4
-#define ELEM_O_LEN  4
-#define ELEM_C_FST  8
-#define ELEM_C_LEN  2
-
 #define MAX_NEIGH 6
 
     int i, n, n2, i1, i2, i3, i4, type, chrg;
@@ -1078,17 +1054,16 @@ int remove_ion_pairs( int num_atoms, inp_ATOM *at )
 #endif
 
     inp_ATOM *a;
-    char *p;
+    U_CHAR grp;
 
     /****** count candidates ********/
     for (i = 0, a = at; i < num_atoms; i++, a++)
     {
         if (1 == ( chrg = a->charge ) || -1 == chrg)
         {
-            if ((p = (char*) memchr( en, a->el_number, ne ))) /* djb-rwth: addressing LLVM warning */
+            if ((grp = ion_el_group( a->el_number )))
             {
-                n = (int) ( p - en );
-                if (n >= ELEM_C_FST)
+                if (grp == EL_NUMBER_C)
                 {
                     if (chrg > 0)
                     {
@@ -1099,7 +1074,7 @@ int remove_ion_pairs( int num_atoms, inp_ATOM *at )
                         num_C_minus++;
                     }
                 }
-                else if (n >= ELEM_O_FST)
+                else if (grp == EL_NUMBER_O)
                 {
                     if (chrg > 0)
                     {
@@ -1110,7 +1085,7 @@ int remove_ion_pairs( int num_atoms, inp_ATOM *at )
                         num_O_minus++;
                     }
                 }
-                else
+                else // grp == EL_NUMBER_N
                 {
                     if (chrg > 0)
                     {
@@ -1129,7 +1104,7 @@ int remove_ion_pairs( int num_atoms, inp_ATOM *at )
         }
         else if (!chrg && a->chem_bonds_valence + NUMH( a, 0 ) == 2 &&
                   get_el_valence( a->el_number, 0, 0 ) == 4 &&
-                  NULL != memchr( en + ELEM_C_FST, a->el_number, ELEM_C_LEN ))
+                  ion_el_group( a->el_number ) == EL_NUMBER_C)
         {
             num_C_II++;
         }
@@ -1165,7 +1140,7 @@ int remove_ion_pairs( int num_atoms, inp_ATOM *at )
             {
                 if (1 == at[i].charge && 3 == nNoMetalNumBonds( at, i ) &&
                      4 == nNoMetalBondsValence( at, i ) &&
-                     NULL != memchr( en + ELEM_N_FST, at[i].el_number, ELEM_N_LEN ))
+                     ion_el_group( at[i].el_number ) == EL_NUMBER_N)
                 {
                     int num_OM = 0, ord_OM[3]; /* -O(-) */
                     int num_O = 0; /* =O    */
@@ -1174,7 +1149,7 @@ int remove_ion_pairs( int num_atoms, inp_ATOM *at )
                     {
                         n = at[i].neighbor[i1];
                         if (1 == nNoMetalNumBonds( at, n ) && 0 == num_of_H( at, n ) &&
-                             NULL != ( p = (char*) memchr( en + ELEM_O_FST, at[n].el_number, ELEM_O_LEN ) )) /* djb-rwth: ignoring LLVM warning: variable used */
+                            ion_el_group( at[n].el_number) == EL_NUMBER_O) /* djb-rwth: ignoring LLVM warning: variable used */
                         {
                             if (BOND_TYPE_SINGLE == at[i].bond_type[i1] &&
                                  -1 == at[n].charge)
@@ -1232,7 +1207,7 @@ int remove_ion_pairs( int num_atoms, inp_ATOM *at )
             {
                 if (1 == at[i].charge && 4 == nNoMetalNumBonds( at, i ) &&
                      4 == nNoMetalBondsValence( at, i ) &&
-                     NULL != memchr( en + ELEM_N_FST + 1, at[i].el_number, ELEM_N_LEN - 1 ))
+                     at[i].el_number != EL_NUMBER_N && ion_el_group( at[i].el_number ) == EL_NUMBER_N)
                 {
                     int num_OM = 0, ord_OM[4]; /* -O(-) */
                                                /*int num_O  = 0;*/ /* =O    */
@@ -1241,7 +1216,7 @@ int remove_ion_pairs( int num_atoms, inp_ATOM *at )
                     {
                         n = at[i].neighbor[i1];
                         if (1 == nNoMetalNumBonds( at, n ) && 0 == num_of_H( at, n ) &&
-                             NULL != ( p = (char*) memchr( en + ELEM_O_FST, at[n].el_number, ELEM_O_LEN ) )) /* djb-rwth: ignoring LLVM warning: variable used */
+                            ion_el_group( at[n].el_number) == EL_NUMBER_O) /* djb-rwth: ignoring LLVM warning: variable used */
                         {
                             if (BOND_TYPE_SINGLE == at[i].bond_type[i1] &&
                                  -1 == at[n].charge)
@@ -1303,7 +1278,7 @@ int remove_ion_pairs( int num_atoms, inp_ATOM *at )
             {
                 if (0 == at[i].charge && 1 == nNoMetalNumBonds( at, i ) && 2 == nNoMetalBondsValence( at, i ) &&
                      0 == num_of_H( at, i ) &&
-                     NULL != memchr( en + ELEM_O_FST, at[i].el_number, ELEM_O_LEN ) &&
+                     ion_el_group( at[i].el_number ) == EL_NUMBER_O &&
                      0 <= ( i1 = nNoMetalNeighIndex( at, i ) ) &&
                      at[i].bond_type[i1] <= BOND_TYPE_TRIPLE)
                 {
@@ -1315,7 +1290,7 @@ int remove_ion_pairs( int num_atoms, inp_ATOM *at )
                         if (0 == at[n].charge &&
                              2 == nNoMetalNumBonds( at, n ) && 3 == nNoMetalBondsValence( at, n ) &&
                              0 == num_of_H( at, n ) &&
-                             NULL != memchr( en + ELEM_N_FST, at[n].el_number, ELEM_N_LEN ) &&
+                             ion_el_group( at[n].el_number ) == EL_NUMBER_N &&
                              0 <= ( i2 = nNoMetalOtherNeighIndex( at, n, i ) ) &&
                              at[n].bond_type[i2] <= BOND_TYPE_TRIPLE)
                         {
@@ -1325,7 +1300,7 @@ int remove_ion_pairs( int num_atoms, inp_ATOM *at )
                             if (0 == at[n2].charge &&
                                  2 == at[n2].valence && 2 == at[n2].chem_bonds_valence &&
                                  0 == num_of_H( at, n2 ) &&
-                                 NULL != memchr( en + ELEM_C_FST, at[n2].el_number, ELEM_C_LEN ))
+                                 ion_el_group( at[n2].el_number ) == EL_NUMBER_C)
                             {
                                 /*       i n n2     */
                                 /* found O=N-C(II)- */
@@ -1349,7 +1324,7 @@ int remove_ion_pairs( int num_atoms, inp_ATOM *at )
                     {
                         if (1 == at[n].charge && 2 == nNoMetalNumBonds( at, n ) && 3 == nNoMetalBondsValence( at, n ) &&
                              0 == num_of_H( at, n ) &&
-                             NULL != memchr( en + ELEM_O_FST, at[n].el_number, ELEM_O_LEN ) &&
+                             ion_el_group( at[n].el_number ) == EL_NUMBER_O &&
                              0 <= ( i2 = nNoMetalOtherNeighIndex( at, n, i ) ) &&
                              at[n].bond_type[i2] <= BOND_TYPE_TRIPLE)
                         {
@@ -1358,7 +1333,7 @@ int remove_ion_pairs( int num_atoms, inp_ATOM *at )
                             /*i2 = (at[n].neighbor[0] == i);*/
                             n2 = at[n].neighbor[i2];
                             if (-1 == at[n2].charge && 3 >= nNoMetalNumBonds( at, n2 ) && 3 == nNoMetalBondsValence( at, n2 ) + NUMH( at, n2 ) &&
-                                 NULL != memchr( en + ELEM_C_FST, at[n2].el_number, ELEM_C_LEN ))
+                                 ion_el_group( at[n2].el_number ) == EL_NUMBER_C)
                             {
                                 /*             i n    n2        */
                                 /* found found O=O(+)-C(-)(III) */
@@ -1385,7 +1360,7 @@ int remove_ion_pairs( int num_atoms, inp_ATOM *at )
                           0 < num_N_plus + num_O_plus + num_C_plus &&
                           1 == nNoMetalNumBonds( at, i ) && 1 == nNoMetalBondsValence( at, i ) &&
                           0 == num_of_H( at, i ) &&
-                          NULL != memchr( en + ELEM_O_FST, at[i].el_number, ELEM_O_LEN ) &&
+                          ion_el_group( at[i].el_number ) == EL_NUMBER_O &&
                           0 <= ( i1 = nNoMetalNeighIndex( at, i ) ) &&
                           at[i].bond_type[i1] <= BOND_TYPE_TRIPLE)
                 {
@@ -1395,7 +1370,7 @@ int remove_ion_pairs( int num_atoms, inp_ATOM *at )
                     if (( !type || type == 4 ) && 0 < num_O_minus && 0 < num_N_plus && /* O(-)-N(+)(IV) */
                          1 == at[n].charge && 3 >= nNoMetalNumBonds( at, n ) && 4 == nNoMetalBondsValence( at, n ) &&
                          0 == num_of_H( at, n ) &&
-                         NULL != memchr( en + ELEM_N_FST, at[n].el_number, ELEM_N_LEN ) /* except >O(+)- */
+                         ion_el_group( at[n].el_number ) == EL_NUMBER_N /* except >O(+)- */
                          )
                     {
                         /* found O(-)-N(+)(IV) */
@@ -1418,7 +1393,7 @@ int remove_ion_pairs( int num_atoms, inp_ATOM *at )
                     if (( !type || type == 5 ) && 0 < num_O_minus && 0 < num_O_plus &&/* O(-)-O(+)(III) */
                          1 == at[n].charge && 3 >= nNoMetalNumBonds( at, n ) && 3 == nNoMetalBondsValence( at, n ) &&
                          0 == num_of_H( at, n ) &&
-                         NULL != memchr( en + ELEM_O_FST, at[n].el_number, ELEM_O_LEN ) /* except >O(+)- */
+                         ion_el_group( at[n].el_number ) == EL_NUMBER_O /* except >O(+)- */
                          )
                     {
                         /* found  O(+)(III) */
@@ -1443,7 +1418,7 @@ int remove_ion_pairs( int num_atoms, inp_ATOM *at )
                          0 < num_O_minus && 0 < num_C_plus &&
                          0 == at[n].charge && 2 == nNoMetalNumBonds( at, n ) && 2 == nNoMetalBondsValence( at, n ) &&
                          0 == num_of_H( at, n ) &&
-                         NULL != memchr( en + ELEM_O_FST, at[n].el_number, ELEM_O_LEN ) &&
+                         ion_el_group( at[n].el_number ) == EL_NUMBER_O &&
                          0 <= ( i2 = nNoMetalOtherNeighIndex( at, n, i ) ) &&
                          at[n].bond_type[i2] <= BOND_TYPE_TRIPLE)
                     {
@@ -1453,7 +1428,7 @@ int remove_ion_pairs( int num_atoms, inp_ATOM *at )
                         n2 = at[n].neighbor[i2];
                         if (1 == at[n2].charge && 3 >= nNoMetalNumBonds( at, n2 ) &&
                              3 == nNoMetalBondsValence( at, n2 ) + NUMH( at, n2 ) &&
-                             NULL != memchr( en + ELEM_C_FST, at[n2].el_number, ELEM_C_LEN ))
+                             ion_el_group( at[n2].el_number ) == EL_NUMBER_C)
                         {
                             /*       i    n n2  */
                             /* found O(-)-O-C(+)(III) */
@@ -1482,7 +1457,7 @@ int remove_ion_pairs( int num_atoms, inp_ATOM *at )
                 else if (-1 == at[i].charge && 0 < num_N_minus && 0 < num_N_plus + num_O_plus + num_C_plus &&
                           1 == nNoMetalNumBonds( at, i ) && 2 == nNoMetalBondsValence( at, i ) + NUMH( at, i ) &&
                           /*0 == num_of_H( at, i ) &&*/
-                          NULL != memchr( en + ELEM_N_FST, at[i].el_number, ELEM_N_LEN ) &&
+                          ion_el_group( at[i].el_number ) == EL_NUMBER_N &&
                           0 <= ( i1 = nNoMetalNeighIndex( at, i ) ) &&
                           at[i].bond_type[i1] <= BOND_TYPE_TRIPLE)
                 {
@@ -1491,7 +1466,7 @@ int remove_ion_pairs( int num_atoms, inp_ATOM *at )
                     if (( !type || type == 7 ) && 0 < num_N_plus && /* N(-)=N(+)(IV) */
                          1 == at[n].charge && 3 >= nNoMetalNumBonds( at, n ) && 4 == nNoMetalBondsValence( at, n ) &&
                          0 == num_of_H( at, n ) &&
-                         NULL != memchr( en + ELEM_N_FST, at[n].el_number, ELEM_N_LEN ))
+                         ion_el_group( at[n].el_number ) == EL_NUMBER_N)
                     {
                         /* found N(-)-N(+)(IV) */
                         /* convert N(-)=N(+)(IV)     => N#N(V)  */
@@ -1512,7 +1487,7 @@ int remove_ion_pairs( int num_atoms, inp_ATOM *at )
                     if (( !type || type == 8 ) && 0 < num_O_plus && /* N(-)=O(+)(III) */
                          1 == at[n].charge && 2 == nNoMetalNumBonds( at, n ) && 3 == nNoMetalBondsValence( at, n ) &&
                          0 == num_of_H( at, n ) &&
-                         NULL != memchr( en + ELEM_O_FST, at[n].el_number, ELEM_O_LEN ))
+                         ion_el_group( at[n].el_number ) == EL_NUMBER_O)
                     {
                         /* found N(-)-O(+)(III) */
                         /* convert N(-)=O(+)(III)    => N#O(IV)- */
@@ -1532,7 +1507,7 @@ int remove_ion_pairs( int num_atoms, inp_ATOM *at )
                     if (( !type || type == 9 ) && 0 < num_C_plus && /* N(-)=C(+)(III) */
                          1 == at[n].charge && 2 == at[n].valence && 3 == at[n].chem_bonds_valence &&
                          0 == num_of_H( at, n ) &&
-                         NULL != memchr( en + ELEM_C_FST, at[n].el_number, ELEM_C_LEN ))
+                         ion_el_group( at[n].el_number ) == EL_NUMBER_C)
                     {
                         /* found N(-)=C(+)(III) */
                         /* convert N(-)=C(+)(III)    => N#C(IV)- */
@@ -1577,7 +1552,7 @@ int remove_ion_pairs( int num_atoms, inp_ATOM *at )
                      0 < num_N_plus + num_O_plus && 0 < num_C_minus + num_N_minus &&
                      4 >= nNoMetalNumBonds( at, i ) && 4 == nNoMetalBondsValence( at, i ) &&
                      0 == num_of_H( at, i ) &&
-                     NULL != memchr( en + ELEM_N_FST, at[i].el_number, ELEM_N_LEN ))
+                     ion_el_group( at[i].el_number ) == EL_NUMBER_N)
                 {
                     /* found non-terminal N(+)(IV) */
                     if (( !type || 10 == type ) && 0 < num_N_plus && 0 < num_C_minus)
@@ -1589,7 +1564,7 @@ int remove_ion_pairs( int num_atoms, inp_ATOM *at )
                             if (-1 == at[n].charge && 3 >= at[n].valence && 3 == at[n].chem_bonds_valence + NUMH( at, n ) &&
                                  /*0 == at[n].num_H &&*/
                                  at[i].bond_type[i1] == BOND_TYPE_SINGLE &&
-                                 NULL != memchr( en + ELEM_C_FST, at[n].el_number, ELEM_C_LEN ))
+                                 ion_el_group( at[n].el_number ) == EL_NUMBER_C)
                             {
                                 /* found N(+)(IV)-C(-)(III); prepare conversion to N(V)=C(IV) */
                                 num_neigh++;
@@ -1599,8 +1574,8 @@ int remove_ion_pairs( int num_atoms, inp_ATOM *at )
                         i1 = pos_neigh;
                         if (1 == num_neigh &&
                              at[i].bond_type[i1] <= BOND_TYPE_TRIPLE &&
-                             !has_other_ion_neigh( at, i, n = at[i].neighbor[i1], en, ne ) &&
-                             !has_other_ion_neigh( at, n, i, en, ne ))
+                             !has_other_ion_neigh( at, i, n = at[i].neighbor[i1] ) &&
+                             !has_other_ion_neigh( at, n, i ))
                         {
                             /*n = at[i].neighbor[i1=pos_neigh];*/
                             i2 = (int) ( is_in_the_list( at[n].neighbor, (AT_NUMB) i, at[n].valence ) - at[n].neighbor );
@@ -1626,7 +1601,7 @@ int remove_ion_pairs( int num_atoms, inp_ATOM *at )
                             if (-1 == at[n].charge && 3 >= at[n].valence && 3 == at[n].chem_bonds_valence + NUMH( at, n ) &&
                                  /*0 == at[n].num_H &&*/
                                  at[i].bond_type[i1] == BOND_TYPE_DOUBLE &&
-                                 NULL != memchr( en + ELEM_C_FST, at[n].el_number, ELEM_C_LEN ))
+                                 ion_el_group( at[n].el_number ) == EL_NUMBER_C)
                             {
                                 /* found N(+)(IV)=C(-)(III); prepare conversion to N(V)#C(IV) */
                                 num_neigh++;
@@ -1634,8 +1609,8 @@ int remove_ion_pairs( int num_atoms, inp_ATOM *at )
                             }
                         }
                         if (1 == num_neigh &&
-                             !has_other_ion_neigh( at, i, n = at[i].neighbor[i1 = pos_neigh], en, ne ) &&
-                             !has_other_ion_neigh( at, n, i, en, ne ))
+                             !has_other_ion_neigh( at, i, n = at[i].neighbor[i1 = pos_neigh]) &&
+                             !has_other_ion_neigh( at, n, i))
                         {
                             /*n = at[i].neighbor[i1=pos_neigh];*/
                             i2 = (int) ( is_in_the_list( at[n].neighbor, (AT_NUMB) i, at[n].valence ) - at[n].neighbor );
@@ -1662,7 +1637,7 @@ int remove_ion_pairs( int num_atoms, inp_ATOM *at )
                                  2 == nNoMetalBondsValence( at, n ) + NUMH( at, n ) &&
                                  /*0 == num_of_H( at, n ) &&*/
                                  at[i].bond_type[i1] == BOND_TYPE_SINGLE &&
-                                 NULL != memchr( en + ELEM_N_FST, at[n].el_number, ELEM_N_LEN ))
+                                 ion_el_group( at[n].el_number ) == EL_NUMBER_N)
                             {
                                 /* found N(+)(IV)=N(-)(II); prepare conversion to N(V)#N(III) */
                                 num_neigh++;
@@ -1670,8 +1645,8 @@ int remove_ion_pairs( int num_atoms, inp_ATOM *at )
                             }
                         }
                         if (1 == num_neigh &&
-                             !has_other_ion_neigh( at, i, n = at[i].neighbor[i1 = pos_neigh], en, ne ) &&
-                             !has_other_ion_neigh( at, n, i, en, ne ))
+                             !has_other_ion_neigh( at, i, n = at[i].neighbor[i1 = pos_neigh]) &&
+                             !has_other_ion_neigh( at, n, i))
                         {
                             /*n = at[i].neighbor[i1=pos_neigh];*/
                             i2 = (int) ( is_in_the_list( at[n].neighbor, (AT_NUMB) i, at[n].valence ) - at[n].neighbor );
@@ -1693,7 +1668,7 @@ int remove_ion_pairs( int num_atoms, inp_ATOM *at )
                           0 < num_O_plus && 0 < num_C_minus + num_N_minus &&
                           3 >= nNoMetalNumBonds( at, i ) && 3 == nNoMetalBondsValence( at, i ) &&
                           0 == num_of_H( at, i ) &&
-                          NULL != memchr( en + ELEM_O_FST, at[i].el_number, ELEM_O_LEN ))
+                          ion_el_group( at[i].el_number ) == EL_NUMBER_O)
                 {
                     /* found non-terminal O(+)(III) */
                     if (( !type || 13 == type ) && 0 < num_C_minus)
@@ -1705,7 +1680,7 @@ int remove_ion_pairs( int num_atoms, inp_ATOM *at )
                             if (-1 == at[n].charge && 3 >= at[n].valence && 3 == at[n].chem_bonds_valence + NUMH( at, n ) &&
                                  /*0 == at[n].num_H &&*/
                                  at[i].bond_type[i1] == BOND_TYPE_SINGLE &&
-                                 NULL != memchr( en + ELEM_C_FST, at[n].el_number, ELEM_C_LEN ))
+                                 ion_el_group( at[n].el_number ) == EL_NUMBER_C)
                             {
                                 /* found O(+)(III)-C(-)(II); prepare conversion to O(IV)=C(IV) */
                                 num_neigh++;
@@ -1713,8 +1688,8 @@ int remove_ion_pairs( int num_atoms, inp_ATOM *at )
                             }
                         }
                         if (1 == num_neigh &&
-                             !has_other_ion_neigh( at, i, n = at[i].neighbor[i1 = pos_neigh], en, ne ) &&
-                             !has_other_ion_neigh( at, n, i, en, ne ))
+                             !has_other_ion_neigh( at, i, n = at[i].neighbor[i1 = pos_neigh]) &&
+                             !has_other_ion_neigh( at, n, i))
                         {
                             /*n = at[i].neighbor[i1=pos_neigh];*/
                             i2 = (int) ( is_in_the_list( at[n].neighbor, (AT_NUMB) i, at[n].valence ) - at[n].neighbor );
@@ -1740,7 +1715,7 @@ int remove_ion_pairs( int num_atoms, inp_ATOM *at )
                             if (-1 == at[n].charge && 3 >= at[n].valence && 3 == at[n].chem_bonds_valence + NUMH( at, n ) &&
                                  /*0 == at[n].num_H &&*/
                                  at[i].bond_type[i1] == BOND_TYPE_DOUBLE &&
-                                 NULL != memchr( en + ELEM_C_FST, at[n].el_number, ELEM_C_LEN ))
+                                 ion_el_group( at[n].el_number ) == EL_NUMBER_C)
                             {
                                 /* found O(+)(III)=C(-)(III); prepare conversion to O(IV)#C(IV) */
                                 num_neigh++;
@@ -1748,8 +1723,8 @@ int remove_ion_pairs( int num_atoms, inp_ATOM *at )
                             }
                         }
                         if (1 == num_neigh &&
-                             !has_other_ion_neigh( at, i, n = at[i].neighbor[i1 = pos_neigh], en, ne ) &&
-                             !has_other_ion_neigh( at, n, i, en, ne ))
+                             !has_other_ion_neigh( at, i, n = at[i].neighbor[i1 = pos_neigh]) &&
+                             !has_other_ion_neigh( at, n, i))
                         {
                             /*n = at[i].neighbor[i1=pos_neigh];*/
                             i2 = (int) ( is_in_the_list( at[n].neighbor, (AT_NUMB) i, at[n].valence ) - at[n].neighbor );
@@ -1776,7 +1751,7 @@ int remove_ion_pairs( int num_atoms, inp_ATOM *at )
                                  2 == nNoMetalBondsValence( at, n ) + NUMH( at, n ) &&
                                  /*0 == num_of_H( at, n ) &&*/
                                  at[i].bond_type[i1] == BOND_TYPE_SINGLE &&
-                                 NULL != memchr( en + ELEM_N_FST, at[n].el_number, ELEM_N_LEN ))
+                                 ion_el_group( at[n].el_number ) == EL_NUMBER_N)
                             {
                                 /* found O(+)(III)=N(-)(II); prepare conversion to O(IV)#N(III) */
                                 num_neigh++;
@@ -1784,8 +1759,8 @@ int remove_ion_pairs( int num_atoms, inp_ATOM *at )
                             }
                         }
                         if (1 == num_neigh &&
-                             !has_other_ion_neigh( at, i, n = at[i].neighbor[i1 = pos_neigh], en, ne ) &&
-                             !has_other_ion_neigh( at, n, i, en, ne ))
+                             !has_other_ion_neigh( at, i, n = at[i].neighbor[i1 = pos_neigh]) &&
+                             !has_other_ion_neigh( at, n, i))
                         {
                             /*n = at[i].neighbor[i1=pos_neigh];*/
                             i2 = (int) ( is_in_the_list( at[n].neighbor, (AT_NUMB) i, at[n].valence ) - at[n].neighbor );
@@ -1834,7 +1809,7 @@ int remove_ion_pairs( int num_atoms, inp_ATOM *at )
                      0 == at[m[0]].charge + at[m[1] = at[i].neighbor[j[1]]].charge &&
                      5 >= nNoMetalBondsValence( at, m[0] ) + nNoMetalBondsValence( at, m[1] ) &&
                      /*5 >= at[m[0]].chem_bonds_valence + at[m[1]].chem_bonds_valence &&*/
-                     NULL != memchr( en + ELEM_O_FST, at[i].el_number, ELEM_O_LEN ))
+                     ion_el_group( at[i].el_number ) == EL_NUMBER_O)
                 {
                     /* found non-terminal A(+)-O-B(-); chem_bond_val of A+B <= 5 */
                     int n_N = -1, n_C = -1, i_C = -1;
@@ -1843,20 +1818,20 @@ int remove_ion_pairs( int num_atoms, inp_ATOM *at )
                         n = m[k];
                         if (-1 == at[n].charge && 2 == nNoMetalNumBonds( at, n ) + NUMH( at, n ) &&
                              /*0 == num_of_H( at, n ) &&*/
-                             NULL != memchr( en + ELEM_N_FST, at[n].el_number, ELEM_N_LEN ))
+                             ion_el_group( at[n].el_number ) == EL_NUMBER_N)
                         {
                             n_N = n;
                         }
                         else if (1 == at[n].charge && 3 == at[n].chem_bonds_valence + NUMH( at, n ) &&
-                                  NULL != memchr( en + ELEM_C_FST, at[n].el_number, ELEM_C_LEN ))
+                                  ion_el_group( at[n].el_number ) == EL_NUMBER_C)
                         {
                             n_C = n;
                             i_C = k;
                         }
                     }
                     if (n_C < 0 || n_N < 0 ||
-                         has_other_ion_in_sphere_2( at, n_C, n_N, en, ne ) ||
-                         has_other_ion_in_sphere_2( at, n_N, n_C, en, ne ))
+                         has_other_ion_in_sphere_2( at, n_C, n_N) ||
+                         has_other_ion_in_sphere_2( at, n_N, n_C))
                     {
                         continue;
                     }
@@ -1898,7 +1873,7 @@ int remove_ion_pairs( int num_atoms, inp_ATOM *at )
                      2 == ( 3 == ( c[0] ? at[m[0]].chem_bonds_valence + NUMH( at, m[0] ) : 0 ) )
                      + ( 3 == ( c[1] ? at[m[1]].chem_bonds_valence + NUMH( at, m[1] ) : 0 ) )
                      + ( 3 == ( c[2] ? at[m[2]].chem_bonds_valence + NUMH( at, m[2] ) : 0 ) ) &&
-                     NULL != memchr( en + ELEM_N_FST, at[i].el_number, ELEM_N_LEN ))
+                     ion_el_group( at[i].el_number ) == EL_NUMBER_N)
                 {
                     /* found non-terminal A(+)-O-B(-) */
                     int n_Cp = -1, n_Cm = -1, i_Cp = -1, i_Cm = -1; /* p = positive, m = negatice ion C */
@@ -1908,13 +1883,13 @@ int remove_ion_pairs( int num_atoms, inp_ATOM *at )
                         {
                             n = m[k];
                             if (-1 == at[n].charge &&
-                                 NULL != memchr( en + ELEM_C_FST, at[n].el_number, ELEM_C_LEN ))
+                                 ion_el_group( at[n].el_number ) == EL_NUMBER_C)
                             {
                                 n_Cm = n;
                                 i_Cm = k;
                             }
                             else if (1 == at[n].charge &&
-                                      NULL != memchr( en + ELEM_C_FST, at[n].el_number, ELEM_C_LEN ))
+                                      ion_el_group( at[n].el_number ) == EL_NUMBER_C)
                             {
                                 n_Cp = n;
                                 i_Cp = k;
@@ -1922,8 +1897,8 @@ int remove_ion_pairs( int num_atoms, inp_ATOM *at )
                         }
                     }
                     if (n_Cp < 0 || n_Cm < 0 ||
-                         has_other_ion_in_sphere_2( at, n_Cp, n_Cm, en, ne ) ||
-                         has_other_ion_in_sphere_2( at, n_Cm, n_Cp, en, ne ))
+                         has_other_ion_in_sphere_2( at, n_Cp, n_Cm) ||
+                         has_other_ion_in_sphere_2( at, n_Cm, n_Cp))
                     {
                         continue;
                     }
@@ -1963,9 +1938,9 @@ int remove_ion_pairs( int num_atoms, inp_ATOM *at )
                      6 == ( v[0] = at[m[0]].chem_bonds_valence + NUMH( at, m[0] ) )
                      + ( v[1] = at[m[1]].chem_bonds_valence + NUMH( at, m[1] ) ) &&
                      2 >= abs( v[0] - v[1] ) &&
-                     NULL != memchr( en + ELEM_N_FST, at[i].el_number, ELEM_N_LEN ) &&
-                     NULL != memchr( en + ELEM_C_FST, at[m[0]].el_number, ELEM_C_LEN ) &&
-                     NULL != memchr( en + ELEM_C_FST, at[m[1]].el_number, ELEM_C_LEN ))
+                     ion_el_group( at[i].el_number ) == EL_NUMBER_N &&
+                     ion_el_group( at[m[0]].el_number ) == EL_NUMBER_C &&
+                     ion_el_group( at[m[1]].el_number ) == EL_NUMBER_C)
                 {
                     /*                    n_Cm      i n_Cp */
                     /* found non-terminal C(-)(III)-N=C(+)(III) or C(IV)=N-C(II): Cm-N-Cp */
@@ -1995,7 +1970,7 @@ int remove_ion_pairs( int num_atoms, inp_ATOM *at )
                         {
                             /* neighbor of at[n_Cp] opposite to at[i] */
                             k = at[n_Cp].neighbor[at[n_Cp].neighbor[0] == i];
-                            if (NULL != memchr( en + ELEM_N_FST, at[k].el_number, ELEM_N_LEN ))
+                            if (ion_el_group( at[k].el_number ) == EL_NUMBER_N)
                             {
                                 continue;
                             }
@@ -2003,8 +1978,8 @@ int remove_ion_pairs( int num_atoms, inp_ATOM *at )
                     }
                     else if (at[n_Cp].charge)
                     {
-                        if (has_other_ion_in_sphere_2( at, n_Cp, n_Cm, en, ne ) ||
-                             has_other_ion_in_sphere_2( at, n_Cm, n_Cp, en, ne ))
+                        if (has_other_ion_in_sphere_2( at, n_Cp, n_Cm) ||
+                             has_other_ion_in_sphere_2( at, n_Cm, n_Cp))
                         {
                             continue;
                         }

--- a/INCHI-1-SRC/INCHI_BASE/src/util.c
+++ b/INCHI-1-SRC/INCHI_BASE/src/util.c
@@ -1115,12 +1115,39 @@ int num_of_H( inp_ATOM *at, int iat )
     return num_explicit_H + NUMH( at, iat );
 }
 
+/****************************************************************************/
+/* Get the element group of an element. The base element rather than the    */
+/* periodic group is used to aid readability.                               */
+/* - NitrogenGroup = 7 (EL_NUMBER_N)                                        */
+/* - OxygenGroup   = 8 (EL_NUMBER_O)                                        */
+/* - Cargbon       = 6 (EL_NUMBER_C)                                        */
+/****************************************************************************/
+U_CHAR ion_el_group( int el )
+{
+    switch ( el ) {
+        case EL_NUMBER_C: /* fallthrough */
+#if ( FIX_REM_ION_PAIRS_Si_BUG == 1 )        
+        case EL_NUMBER_SI:
+#endif        
+            return EL_NUMBER_C;
+        case EL_NUMBER_N: /* fallthrough */
+        case EL_NUMBER_P:
+        case EL_NUMBER_AS:
+        case EL_NUMBER_SB:
+            return EL_NUMBER_N;
+        case EL_NUMBER_O: /* fallthrough */
+        case EL_NUMBER_S:
+        case EL_NUMBER_SE:
+        case EL_NUMBER_TE:
+            return EL_NUMBER_O;
+        default:
+            return 0;
+    }
+}
 
 int has_other_ion_neigh( inp_ATOM *at,
                          int iat,
-                         int iat_ion_neigh,
-                         const char *el,
-                         int el_len )
+                         int iat_ion_neigh)
 {
     int charge = at[iat_ion_neigh].charge;
     int i, neigh;
@@ -1130,7 +1157,7 @@ int has_other_ion_neigh( inp_ATOM *at,
         neigh = at[iat].neighbor[i];
 
         if (neigh != iat_ion_neigh && at[neigh].charge == charge &&
-             NULL != memchr( el, at[neigh].el_number, el_len ))
+            ion_el_group( at[neigh].el_number ))
         {
             return 1;
         }
@@ -1145,8 +1172,7 @@ int has_other_ion_neigh( inp_ATOM *at,
     BFS r=2
 ****************************************************************************/
 int has_other_ion_in_sphere_2( inp_ATOM *at, int iat,
-                               int iat_ion_neigh,
-                               const char *el, int el_len )
+                               int iat_ion_neigh )
 {
 #define MAXQ 16
     AT_NUMB q[MAXQ];
@@ -1170,7 +1196,7 @@ int has_other_ion_in_sphere_2( inp_ATOM *at, int iat,
 
                 if (!at[neigh].cFlags &&
                      at[neigh].valence <= 3 &&
-                     NULL != memchr( el, at[neigh].el_number, el_len ))
+                     ion_el_group( at[neigh].el_number ))
                 {
                     q[lenq++] = neigh;
                     at[neigh].cFlags = 1;

--- a/INCHI-1-SRC/INCHI_BASE/src/util.h
+++ b/INCHI-1-SRC/INCHI_BASE/src/util.h
@@ -174,8 +174,9 @@ extern "C" {
 
 
     int num_of_H( inp_ATOM *at, int iat );
-    int has_other_ion_neigh( inp_ATOM *at, int iat, int iat_ion_neigh, const char *el, int el_len );
-    int has_other_ion_in_sphere_2( inp_ATOM *at, int iat, int iat_ion_neigh, const char *el, int el_len );
+    U_CHAR ion_el_group( int el );
+    int has_other_ion_neigh( inp_ATOM *at, int iat, int iat_ion_neigh );
+    int has_other_ion_in_sphere_2( inp_ATOM *at, int iat, int iat_ion_neigh);
     int nNoMetalNumBonds( inp_ATOM *at, int at_no );
     int nNoMetalBondsValence( inp_ATOM *at, int at_no );
     int nNoMetalNeighIndex( inp_ATOM *at, int at_no );


### PR DESCRIPTION
In several places a memchr() is used to check which group an atom belongs to, e.g. is N,P,As, or Sb (nitrogen group) or O,S,Se,Te (oxygen group). It is clearer to test this with a function with maps the integer down to the first element of the group, in some places there are checks for "nitrogen group but not nitrogen".

I have tested regressions against ChEMBL but please do the full check as there are lots of fiddly changes here.
