### PR TITLE
allow customization of test library path location

### DIFF
--- a/INCHI-1-TEST/compile_inchi_lib.sh
+++ b/INCHI-1-TEST/compile_inchi_lib.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-inchi_version=$1
+inchi_version=$1 # Must be one of the tags in `git tag` or branches in `git branch`.
 inchi_lib_dir=$2 # Path must be absolute.
 current_branch=$(git rev-parse --abbrev-ref HEAD)
 makefile_dir="INCHI-1-SRC/INCHI_API/libinchi/gcc"

--- a/INCHI-1-TEST/config/config.invariance.py
+++ b/INCHI-1-TEST/config/config.invariance.py
@@ -1,7 +1,8 @@
 from inchi_tests.config_models import TestConfig
+from pathlib import Path
 
 
 config = TestConfig(
     name="invariance",
-    inchi_version="main",
+    inchi_library_path=Path("INCHI-1-TEST/libs/libinchi.so.main"),
 )

--- a/INCHI-1-TEST/config/config.regression.py
+++ b/INCHI-1-TEST/config/config.regression.py
@@ -1,7 +1,8 @@
 from inchi_tests.config_models import TestConfig
+from pathlib import Path
 
 
 config = TestConfig(
     name="regression",
-    inchi_version="main",
+    inchi_library_path=Path("INCHI-1-TEST/libs/libinchi.so.main"),
 )

--- a/INCHI-1-TEST/config/config.regression_reference.py
+++ b/INCHI-1-TEST/config/config.regression_reference.py
@@ -1,7 +1,8 @@
 from inchi_tests.config_models import TestConfig
+from pathlib import Path
 
 
 config = TestConfig(
     name="regression-reference",
-    inchi_version="v1.06",
+    inchi_library_path=Path("INCHI-1-TEST/libs/libinchi.so.v1.06"),
 )

--- a/INCHI-1-TEST/docs/README.md
+++ b/INCHI-1-TEST/docs/README.md
@@ -83,7 +83,7 @@ The 2nd run results in a regression, since the output no longer matches the refe
 run-tests --test-config=INCHI-1-TEST/config/config.regression_reference.py --data-config=INCHI-1-TEST/config/config.<dataset>.py
 ```
 
-uses `libinchi.so.<version>`, the shared library belonging to the version specified with `--test-config`,
+uses `libinchi.so.<version>`, the shared library specified with `--test-config`,
 and generates an `<SDF>.regression_reference.sqlite` file for each SDF under `INCHI-1-TEST/data/<dataset>`.
 The `sqlite` file contains a table with the results for each molfile.
 
@@ -201,7 +201,7 @@ We provide two [templates](INCHI-1-TEST/src/inchi_tests/config_models.py) under 
 
 Lets you customize the test itself, e.g.,
 configuring what to run ("regression", "regression-reference", or "invariance"),
-which InChI version to use, and which parameters to pass to the InChI API.
+which InChI library to use, and which parameters to pass to the InChI API.
 For details, have a look at the comments in the `TestConfig` class.
 Your configuration file, e.g., `config/custom-regression.py` must contain an instance of `TestConfig` called `config`.
 For an example of how to instantiate a `TestConfig` object, have a look at our [regression configuration](INCHI-1-TEST/config/config.regression.py).

--- a/INCHI-1-TEST/src/inchi_tests/config_models.py
+++ b/INCHI-1-TEST/src/inchi_tests/config_models.py
@@ -11,9 +11,8 @@ class TestConfig(BaseModel):
     # All paths are relative to the root of the repository.
 
     name: Literal["regression", "regression-reference", "invariance"]
-    # Version that's being used for compiling the InChI API binary.
-    # Must be one of the tags in `git tag` or branches in `git branch`.
-    inchi_version: str
+    # Path to the InChI shared library.
+    inchi_library_path: FilePath
     # Parameters to pass to the InChI API.
     inchi_api_parameters: str = ""
     # Permute each structure N times.

--- a/INCHI-1-TEST/src/inchi_tests/run_tests.py
+++ b/INCHI-1-TEST/src/inchi_tests/run_tests.py
@@ -38,13 +38,8 @@ def main() -> None:
         f"{datetime.now().strftime('%Y%m%dT%H%M%S')}_{test}_{dataset}.log"
     )
     n_processes = test_config.n_processes
-    inchi_version = test_config.inchi_version
     inchi_api_parameters = test_config.inchi_api_parameters
-    inchi_lib_dir = Path("INCHI-1-TEST/libs")
-    inchi_lib_path = inchi_lib_dir.joinpath(f"libinchi.so.{inchi_version}")
-    if not inchi_lib_path.exists():
-        logging.error(f"libinchi.so.{inchi_version} not found in {inchi_lib_dir}.")
-        raise SystemExit(1)
+    inchi_lib_path = test_config.inchi_library_path
 
     gcc_version = subprocess.run(
         "gcc -dumpversion",
@@ -56,7 +51,7 @@ def main() -> None:
 
     logging.basicConfig(filename=log_path, encoding="utf-8", level=logging.INFO)
     logging.info(
-        f"{get_current_time()}: InChI '{inchi_version}' compiled with GCC {gcc_version}."
+        f"{get_current_time()}: Using '{inchi_lib_path}' compiled with GCC {gcc_version}."
     )
     logging.info(
         f"{get_current_time()}: Starting to process {n_sdf} SDFs on {n_processes} cores."


### PR DESCRIPTION
this adds a new --library-path command line argument, when set it will override the default logic for setting the library file path