### PR TITLE
Remove SDF_LBL_VAL macro

### DIFF
--- a/.github/actions/compile_inchi_lib/action.yaml
+++ b/.github/actions/compile_inchi_lib/action.yaml
@@ -1,4 +1,4 @@
-name: Compile InChI library from triggering branch
+name: Compile InChI library from triggering commit
 
 runs:
   using: "composite"
@@ -6,12 +6,10 @@ runs:
     - run: |
         git config --global --add safe.directory "$GITHUB_WORKSPACE" # https://github.com/actions/runner-images/issues/6775
         mkdir "$GITHUB_WORKSPACE/$LIB_DIR"
-        ./INCHI-1-TEST/compile_inchi_lib.sh $BRANCH "$GITHUB_WORKSPACE/$LIB_DIR"
-        if [ "$BRANCH" != "main" ]; then
-          # Rename library to libinchi.so.main, since that's the name the tests expect.
-          mv "$GITHUB_WORKSPACE/$LIB_DIR/libinchi.so.$BRANCH" "$GITHUB_WORKSPACE/$LIB_DIR/libinchi.so.main"
-        fi
+        ./INCHI-1-TEST/compile_inchi_lib.sh $COMMIT "$GITHUB_WORKSPACE/$LIB_DIR"
+        # Rename library to libinchi.so.main, since that's the name the tests expect.
+        mv "$GITHUB_WORKSPACE/$LIB_DIR/libinchi.so.$COMMIT" "$GITHUB_WORKSPACE/$LIB_DIR/libinchi.so.main"
       shell: bash
       env:
-        BRANCH: ${{ github.ref_name }}
+        COMMIT: ${{ github.sha }}
         LIB_DIR: INCHI-1-TEST/libs

--- a/INCHI-1-SRC/INCHI_BASE/src/ichi_io.c
+++ b/INCHI-1-SRC/INCHI_BASE/src/ichi_io.c
@@ -1738,9 +1738,9 @@ int Output_RecordInfo(INCHI_IOSTREAM   *out_file,
     }
     else
     {
-        inchi_ios_print_nodisplay(out_file, "%sStructure: %d.%s%s%s%s",
+        inchi_ios_print_nodisplay(out_file, "%sStructure: %d.%s",
             pLF, num_input_struct,
-            SDF_LBL_VAL(szSdfLabel, szSdfValue));
+            get_sdf_lbl_val(szSdfLabel, szSdfValue));
 
         if (lSdfId)
         {

--- a/INCHI-1-SRC/INCHI_BASE/src/ichimake.c
+++ b/INCHI-1-SRC/INCHI_BASE/src/ichimake.c
@@ -2531,8 +2531,8 @@ int ProcessStructError( INCHI_IOSTREAM *out_file,
         {
             if (!( b_ok = OutputINChIPlainError( out_file, pStrErrStruct, nErrorType ) ))
             {
-                inchi_ios_eprint( log_file, "Cannot create message for error (structure #%ld.%s%s%s%s) Terminating.\n",
-                                                            num_inp, SDF_LBL_VAL( ip->pSdfLabel, ip->pSdfValue ) );
+                inchi_ios_eprint( log_file, "Cannot create message for error (structure #%ld.%s) Terminating.\n",
+                                                            num_inp, get_sdf_lbl_val( ip->pSdfLabel, ip->pSdfValue ) );
             }
             else
             {

--- a/INCHI-1-SRC/INCHI_BASE/src/ichiprt1.c
+++ b/INCHI-1-SRC/INCHI_BASE/src/ichiprt1.c
@@ -1177,8 +1177,8 @@ int OutputINChI1( CANON_GLOBALS *pCG,
     memset( io.sDifSegs, DIFV_BOTH_EMPTY, sizeof( io.sDifSegs ) ); /* djb-rwth: memset_s C11/Annex K variant? */
     if (!strbuf || !( strbuf->pStr ) || strbuf->nAllocatedLength <= 0)
     {
-        inchi_ios_eprint( log_file, "Cannot allocate output buffer. No output for structure #%d.%s%s%s%s\n",
-                         num_input_struct, SDF_LBL_VAL( ip->pSdfLabel, ip->pSdfValue ) );
+        inchi_ios_eprint( log_file, "Cannot allocate output buffer. No output for structure #%d.%s\n",
+                         num_input_struct, get_sdf_lbl_val( ip->pSdfLabel, ip->pSdfValue ) );
         return ret;
     }
 
@@ -2075,8 +2075,8 @@ exit_function:
     if (intermediate_result)
     {
         ret = 0;
-        inchi_ios_eprint( log_file, "InChI serialization error for structure #%d.%s%s%s%s\n",
-                                    num_input_struct, SDF_LBL_VAL( ip->pSdfLabel, ip->pSdfValue ) );
+        inchi_ios_eprint( log_file, "InChI serialization error for structure #%d.%s\n",
+                                    num_input_struct, get_sdf_lbl_val( ip->pSdfLabel, ip->pSdfValue ) );
     }
 
     return ret;

--- a/INCHI-1-SRC/INCHI_BASE/src/runichi.c
+++ b/INCHI-1-SRC/INCHI_BASE/src/runichi.c
@@ -199,17 +199,6 @@ static int OrigAtData_CheckForSubstructure(ORIG_ATOM_DATA *orig_inp_data);
 #endif
 
 
-/**********************************************
- * output " L=V" or " L missing" or ""
- * The fprintf format string must contain %s%s%s%s
- */
-const char gsMissing[] = "is missing";
-const char gsEmpty[] = "";
-const char gsSpace[] = " ";
-const char gsEqual[] = "=";
-
-
-
 /****************************************************************************
  Process a portion of input data (molecule, InChI string, ...)
  in a relevant way (generate InChI, restore molecule by InChI )

--- a/INCHI-1-SRC/INCHI_BASE/src/runichi.c
+++ b/INCHI-1-SRC/INCHI_BASE/src/runichi.c
@@ -554,7 +554,7 @@ int OrigAtData_SaveMolfile( ORIG_ATOM_DATA  *orig_inp_data,
     else
     {
         char szNumber[256];
-        sprintf(szNumber, "Structure #%ld. %s%s%s%s", num_inp, SDF_LBL_VAL(ip->pSdfLabel, ip->pSdfValue));
+        sprintf(szNumber, "Structure #%ld. %s", num_inp, get_sdf_lbl_val(ip->pSdfLabel, ip->pSdfValue));
         ret = OrigAtData_WriteToSDfile( orig_inp_data, out_file, szNumber, NULL,
                                         ( sd->bChiralFlag&FLAG_INP_AT_CHIRAL ) ? 1 : 0,
                                         ( ip->bINChIOutputOptions&INCHI_OUT_SDFILE_ATOMS_DT ) ? 1 : 0,
@@ -1312,15 +1312,15 @@ int CreateOneStructureINChI( CANON_GLOBALS          *pCG,
         {
             if (cur_prep_inp_data->num_components == 1)
             {
-                sprintf(szTitle, "%sInput Structure #%ld.%s%s%s%s%s",
+                sprintf(szTitle, "%sInput Structure #%ld.%s%s",
                     bStructurePreprocessed ? "Preprocessed " : "",
-                    num_inp, SDF_LBL_VAL(ip->pSdfLabel, ip->pSdfValue), iINChI ? " (Reconnected)" : "");
+                    num_inp, get_sdf_lbl_val(ip->pSdfLabel, ip->pSdfValue), iINChI ? " (Reconnected)" : "");
             }
             else
             {
-                sprintf(szTitle, "Component #%d of %d, Input Structure #%ld.%s%s%s%s%s",
+                sprintf(szTitle, "Component #%d of %d, Input Structure #%ld.%s%s",
                     i + 1, cur_prep_inp_data->num_components,
-                    num_inp, SDF_LBL_VAL(ip->pSdfLabel, ip->pSdfValue), iINChI ? " (Reconnected)" : "");
+                    num_inp, get_sdf_lbl_val(ip->pSdfLabel, ip->pSdfValue), iINChI ? " (Reconnected)" : "");
             }
 
 #if defined (TARGET_EXE_STANDALONE) && defined(_WIN32)
@@ -1463,21 +1463,21 @@ int CreateOneStructureINChI( CANON_GLOBALS          *pCG,
                             /*  Added number of components, added another format for a single component case - DCh */
                             if (cur_prep_inp_data->num_components > 1)
                             {
-                                sprintf(szTitle, "%s Component #%d of %d, Structure #%ld%s%s.%s%s%s%s%s",
+                                sprintf(szTitle, "%s Component #%d of %d, Structure #%ld%s%s.%s%s",
                                     bFixedBondsTaut ? "Preprocessed" : "Result for",
                                     i + 1, cur_prep_inp_data->num_components, num_inp,
                                     bDisplayTaut == 1 ? ", mobile H" : bDisplayTaut == 0 ? ", fixed H" : "",
                                     bIsotopic ? ", isotopic" : "",
-                                    SDF_LBL_VAL(ip->pSdfLabel, ip->pSdfValue), iINChI ? " (Reconnected)" : "");
+                                    get_sdf_lbl_val(ip->pSdfLabel, ip->pSdfValue), iINChI ? " (Reconnected)" : "");
                             }
                             else
                             {
-                                sprintf(szTitle, "%s Structure #%ld%s%s.%s%s%s%s%s",
+                                sprintf(szTitle, "%s Structure #%ld%s%s.%s%s",
                                     bFixedBondsTaut ? "Preprocessed" : "Result for",
                                     num_inp,
                                     bDisplayTaut == 1 ? ", mobile H" : bDisplayTaut == 0 ? ", fixed H" : "",
                                     bIsotopic ? ", isotopic" : "",
-                                    SDF_LBL_VAL(ip->pSdfLabel, ip->pSdfValue), iINChI ? " (Reconnected)" : "");
+                                    get_sdf_lbl_val(ip->pSdfLabel, ip->pSdfValue), iINChI ? " (Reconnected)" : "");
                             }
 
 #if defined (TARGET_EXE_STANDALONE) && defined(_WIN32)
@@ -2876,9 +2876,9 @@ int ValidateAndPreparePolymerAndPseudoatoms( struct tagINCHI_CLOCK *ic,
     if (res)
     {
         sd->nErrorCode = res;
-        inchi_ios_eprint( log_file, "Error %d (%s) structure #%ld.%s%s%s%s\n",
+        inchi_ios_eprint( log_file, "Error %d (%s) structure #%ld.%s\n",
                           sd->nErrorCode, sd->pStrErrStruct, num_inp,
-                          SDF_LBL_VAL( ip->pSdfLabel, ip->pSdfValue ) );
+                          get_sdf_lbl_val( ip->pSdfLabel, ip->pSdfValue ) );
         res = _IS_ERROR;
         if (orig_inp_data) /* djb-rwth: fixing a NULL pointer dereference */
             orig_inp_data->num_inp_atoms = -1;

--- a/INCHI-1-SRC/INCHI_BASE/src/runichi2.c
+++ b/INCHI-1-SRC/INCHI_BASE/src/runichi2.c
@@ -368,7 +368,7 @@ int GetOneComponent( INCHI_CLOCK        *ic,
     {
         /*  Log error message */
         AddErrorMessage( sd->pStrErrStruct, "Cannot extract Component" );
-        inchi_ios_eprint( log_file, "%s #%d structure #%ld.%s%s%s%s\n", sd->pStrErrStruct, i + 1, num_inp, SDF_LBL_VAL( ip->pSdfLabel, ip->pSdfValue ) );
+        inchi_ios_eprint( log_file, "%s #%d structure #%ld.%s\n", sd->pStrErrStruct, i + 1, num_inp, get_sdf_lbl_val( ip->pSdfLabel, ip->pSdfValue ) );
         sd->nErrorCode = inp_cur_data->num_at < 0 ? inp_cur_data->num_at : ( orig_inp_data->nCurAtLen[i] != inp_cur_data->num_at ) ? CT_ATOMCOUNT_ERR : CT_UNKNOWN_ERR;
         /* num_err ++; */
         sd->nErrorType = _IS_ERROR;
@@ -730,7 +730,7 @@ int TreatErrorsInReadTheStructure( STRUCT_DATA      *sd,
         /*  End of file */
         if (sd->pStrErrStruct[0])
         {
-            inchi_ios_eprint( log_file, "%s inp structure #%ld: End of file.%s%s%s%s    \n", sd->pStrErrStruct, *num_inp, SDF_LBL_VAL( ip->pSdfLabel, ip->pSdfValue ) );
+            inchi_ios_eprint( log_file, "%s inp structure #%ld: End of file.%s    \n", sd->pStrErrStruct, *num_inp, get_sdf_lbl_val( ip->pSdfLabel, ip->pSdfValue ) );
         }
 
         inchi_ios_eprint( log_file, "End of file detected after structure #%ld.   \n", *num_inp - 1 );
@@ -764,8 +764,8 @@ int TreatErrorsInReadTheStructure( STRUCT_DATA      *sd,
         /*  Fatal error */
         if (nLogMask & LOG_MASK_FATAL)
         {
-            inchi_ios_eprint( log_file, "Fatal Error %d (aborted; %s) inp structure #%ld.%s%s%s%s\n",
-                     sd->nStructReadError, sd->pStrErrStruct, *num_inp, SDF_LBL_VAL( ip->pSdfLabel, ip->pSdfValue ) );
+            inchi_ios_eprint( log_file, "Fatal Error %d (aborted; %s) inp structure #%ld.%s\n",
+                     sd->nStructReadError, sd->pStrErrStruct, *num_inp, get_sdf_lbl_val( ip->pSdfLabel, ip->pSdfValue ) );
         }
 
 #if ( bRELEASE_VERSION == 1 || EXTR_FLAGS == 0 )
@@ -785,9 +785,9 @@ int TreatErrorsInReadTheStructure( STRUCT_DATA      *sd,
         /*  70 => too many atoms */
         if (nLogMask & LOG_MASK_ERR)
         {
-            inchi_ios_eprint( log_file, "Error %d (no %s; %s) inp structure #%ld.%s%s%s%s\n",
+            inchi_ios_eprint( log_file, "Error %d (no %s; %s) inp structure #%ld.%s\n",
                  sd->nStructReadError, ( ip->bINChIOutputOptions & INCHI_OUT_SDFILE_ONLY ) ? "Molfile" : INCHI_NAME,
-                 sd->pStrErrStruct, *num_inp, SDF_LBL_VAL( ip->pSdfLabel, ip->pSdfValue ) );
+                 sd->pStrErrStruct, *num_inp, get_sdf_lbl_val( ip->pSdfLabel, ip->pSdfValue ) );
         }
 
 #if ( bRELEASE_VERSION == 1 || EXTR_FLAGS == 0 )
@@ -804,8 +804,8 @@ int TreatErrorsInReadTheStructure( STRUCT_DATA      *sd,
 
         if (nLogMask & LOG_MASK_WARN)
         {
-            inchi_ios_eprint( log_file, "Warning: (%s) inp structure #%ld.%s%s%s%s\n",
-               sd->pStrErrStruct, *num_inp, SDF_LBL_VAL( ip->pSdfLabel, ip->pSdfValue ) );
+            inchi_ios_eprint( log_file, "Warning: (%s) inp structure #%ld.%s\n",
+               sd->pStrErrStruct, *num_inp, get_sdf_lbl_val( ip->pSdfLabel, ip->pSdfValue ) );
         }
     }
 

--- a/INCHI-1-SRC/INCHI_BASE/src/runichi4.c
+++ b/INCHI-1-SRC/INCHI_BASE/src/runichi4.c
@@ -1397,9 +1397,9 @@ int TreatErrorsInCreateOneComponentINChI( STRUCT_DATA *sd,
     {
         AddErrorMessage( sd->pStrErrStruct, ErrMsg( sd->nErrorCode ) );
         inchi_ios_eprint( log_file,
-                          "Error %d (%s) structure #%ld component %d.%s%s%s%s\n",
+                          "Error %d (%s) structure #%ld component %d.%s\n",
                           sd->nErrorCode, sd->pStrErrStruct,
-                          num_inp, i + 1, SDF_LBL_VAL( ip->pSdfLabel, ip->pSdfValue ) );
+                          num_inp, i + 1, get_sdf_lbl_val( ip->pSdfLabel, ip->pSdfValue ) );
         sd->nErrorType = ( sd->nErrorCode == CT_OUT_OF_RAM || sd->nErrorCode == CT_USER_QUIT_ERR )
             ? _IS_FATAL
             : _IS_ERROR;
@@ -1476,8 +1476,8 @@ int TreatCreateINChIWarning( STRUCT_DATA    *sd,
 
     if (!sd->nErrorCode && sd->pStrErrStruct[0])
     {
-        inchi_ios_eprint( log_file, "Warning (%s) structure #%ld.%s%s%s%s\n",
-            sd->pStrErrStruct, num_inp, SDF_LBL_VAL( ip->pSdfLabel, ip->pSdfValue ) );
+        inchi_ios_eprint( log_file, "Warning (%s) structure #%ld.%s\n",
+            sd->pStrErrStruct, num_inp, get_sdf_lbl_val( ip->pSdfLabel, ip->pSdfValue ) );
         sd->nErrorType = _IS_WARNING;
 
 #ifdef TARGET_LIB_FOR_WINCHI

--- a/INCHI-1-SRC/INCHI_BASE/src/strutil.c
+++ b/INCHI-1-SRC/INCHI_BASE/src/strutil.c
@@ -163,6 +163,17 @@ void add_bond_if_unseen( subgraf_pathfinder *spf,
 #endif
 /****************************************************************************/
 
+const char *get_sdf_lbl_val(const char *lbl, const char *val)
+{
+    if (lbl && lbl[0]) {
+        if (val && val[0]) {
+            return " L=V";
+        } else {
+            return " L is missing";
+        }
+    }
+    return "";
+}
 
 /****************************************************************************/
 int cmp_iso_atw_diff_component_no( const void *a1, const void *a2 )

--- a/INCHI-1-SRC/INCHI_BASE/src/strutil.h
+++ b/INCHI-1-SRC/INCHI_BASE/src/strutil.h
@@ -409,7 +409,7 @@ extern "C" {
 
     int bIsSameBond(int a1, int a2, int b1, int b2);
 
-    // output " L=V" or " L missing" or ""
+    /* output " L=V" or " L missing" or "" */
     const char *get_sdf_lbl_val(const char *lbl, const char *val);
 
     /* Handle integer matrix [mxn] */

--- a/INCHI-1-SRC/INCHI_BASE/src/strutil.h
+++ b/INCHI-1-SRC/INCHI_BASE/src/strutil.h
@@ -409,13 +409,14 @@ extern "C" {
 
     int bIsSameBond(int a1, int a2, int b1, int b2);
 
-    extern const char gsMissing[];
-    extern const char gsEmpty[];
-    extern const char gsSpace[];
-    extern const char gsEqual[];
-
-#define SDF_LBL_VAL(L,V)  ((L)&&(L)[0])?gsSpace:gsEmpty, ((L)&&(L)[0])?L:gsEmpty, ((L)&&(L)[0])? (((V)&&(V)[0])?gsEqual:gsSpace):gsEmpty, ((V)&&(V)[0])?V:((L)&&(L)[0])?gsMissing:gsEmpty
-
+/**********************************************
+ * output " L=V" or " L missing" or ""
+ * The fprintf format string must contain %s%s%s%s
+ *
+ * legacy macro, can be replaced with get_sdf_lbl_val() below
+ */
+#define SDF_LBL_VAL(L, V) get_sdf_lbl_val(L, V), "", "", ""
+    const char *get_sdf_lbl_val(const char *lbl, const char *val);
 
     /* Handle integer matrix [mxn] */
     int  imat_new(int m, int n, int ***a);

--- a/INCHI-1-SRC/INCHI_BASE/src/strutil.h
+++ b/INCHI-1-SRC/INCHI_BASE/src/strutil.h
@@ -409,13 +409,7 @@ extern "C" {
 
     int bIsSameBond(int a1, int a2, int b1, int b2);
 
-/**********************************************
- * output " L=V" or " L missing" or ""
- * The fprintf format string must contain %s%s%s%s
- *
- * legacy macro, can be replaced with get_sdf_lbl_val() below
- */
-#define SDF_LBL_VAL(L, V) get_sdf_lbl_val(L, V), "", "", ""
+    // output " L=V" or " L missing" or ""
     const char *get_sdf_lbl_val(const char *lbl, const char *val);
 
     /* Handle integer matrix [mxn] */

--- a/INCHI-1-SRC/INCHI_EXE/inchi-1/src/ichimain.c
+++ b/INCHI-1-SRC/INCHI_EXE/inchi-1/src/ichimain.c
@@ -1673,7 +1673,7 @@ int RepeatedlyRenumberAtomsAndRecalcINCHI(struct tagINCHI_CLOCK* ic,
     {
         if (very_silent < 2)
         {
-            inchi_ios_eprint(plog, "#%-ld-%08ld\t...\t%-s\t%s%s%s%s\n", *num_inp, 1, ikey0, SDF_LBL_VAL(ip->pSdfLabel, ip->pSdfValue));
+            inchi_ios_eprint(plog, "#%-ld-%08ld\t...\t%-s\t%s\n", *num_inp, 1, ikey0, get_sdf_lbl_val(ip->pSdfLabel, ip->pSdfValue));
         }
     }
 
@@ -1719,7 +1719,7 @@ int RepeatedlyRenumberAtomsAndRecalcINCHI(struct tagINCHI_CLOCK* ic,
                         ndiff++;
                         /*inchi_ios_eprint( plog, "!!! #%-ld-%05ld %s%s%s%s\tcurr %-s != %-s orig\n", *num_inp, irepeat + 2, SDF_LBL_VAL( ip->pSdfLabel, ip->pSdfValue ),  ikey, ikey0  );*/
                         /*inchi_ios_eprint( plog, "!!! %s%s%s%s renum#%05ld\t%-s != %-s\n", SDF_LBL_VAL( ip->pSdfLabel, ip->pSdfValue ), irepeat + 2, ikey, ikey0  );*/
-                        inchi_ios_eprint(plog, "!!! #%-ld %s%s%s%s\t%-s --> %-s @ renum#%06d/%06ld\n", *num_inp, SDF_LBL_VAL(ip->pSdfLabel, ip->pSdfValue), ikey0, ikey, irepeat + 2, nrepeat);
+                        inchi_ios_eprint(plog, "!!! #%-ld %s\t%-s --> %-s @ renum#%06d/%06ld\n", *num_inp, get_sdf_lbl_val(ip->pSdfLabel, ip->pSdfValue), ikey0, ikey, irepeat + 2, nrepeat);
                         if (!very_silent)
                         {
                             int k;
@@ -1765,7 +1765,7 @@ int RepeatedlyRenumberAtomsAndRecalcINCHI(struct tagINCHI_CLOCK* ic,
                     {
                         if (very_silent < 2)
                         {
-                            inchi_ios_eprint(plog, "...........\n#%-ld-%08ld\t...\t%-s\t%s%s%s%s\n", *num_inp, irepeat + 2, ikey0, SDF_LBL_VAL(ip->pSdfLabel, ip->pSdfValue));
+                            inchi_ios_eprint(plog, "...........\n#%-ld-%08ld\t...\t%-s\t%s\n", *num_inp, irepeat + 2, ikey0, get_sdf_lbl_val(ip->pSdfLabel, ip->pSdfValue));
                         }
                     }
 
@@ -1791,7 +1791,7 @@ int RepeatedlyRenumberAtomsAndRecalcINCHI(struct tagINCHI_CLOCK* ic,
                 /*inchi_ios_eprint( plog, "#%-ld-%05ld\t...\tOK ALL\n", *num_inp, nrepeat );*/
                 /*inchi_ios_eprint( plog, "OK  #%-ld %s%s%s%s\n", *num_inp, SDF_LBL_VAL(ip->pSdfLabel, ip->pSdfValue));*/
                 /*inchi_ios_eprint(plog, "#%-ld\n", *num_inp);*/
-                inchi_ios_eprint(plog, "OK  #%-ld %s%s%s%s\t%-s\t Same for %-d/%-d renums\n", *num_inp, SDF_LBL_VAL(ip->pSdfLabel, ip->pSdfValue), ikey0, nrepeat, nrepeat);
+                inchi_ios_eprint(plog, "OK  #%-ld %s\t%-s\t Same for %-d/%-d renums\n", *num_inp, get_sdf_lbl_val(ip->pSdfLabel, ip->pSdfValue), ikey0, nrepeat, nrepeat);
             }
         }
         else

--- a/INCHI-1-TEST/compile_inchi_lib.sh
+++ b/INCHI-1-TEST/compile_inchi_lib.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-inchi_version=$1 # Must be one of the tags in `git tag` or branches in `git branch`.
+inchi_version=$1 # Must be one of the tags in `git tag`, branches in `git branch`, or a commit hash.
 inchi_lib_dir=$2 # Path must be absolute.
 current_branch=$(git rev-parse --abbrev-ref HEAD)
 makefile_dir="INCHI-1-SRC/INCHI_API/libinchi/gcc"
@@ -24,7 +24,6 @@ if [ -n "$(git status --porcelain)" ]; then
     exit 1
 fi
 
-# Check out the specified tag or branch.
 if git rev-parse --verify --quiet refs/tags/$inchi_version; then
     echo "Checking out version tag '$inchi_version'."
     git checkout "tags/$inchi_version"
@@ -32,13 +31,13 @@ if git rev-parse --verify --quiet refs/tags/$inchi_version; then
 fi
 
 if git rev-parse --verify --quiet $inchi_version; then
-    echo "Checking out branch '$inchi_version'."
+    echo "Checking out branch or commit '$inchi_version'."
     git checkout $inchi_version
     checkout_successful=1
 fi
 
 if [ $checkout_successful -eq 0 ]; then
-    echo "Version tag or branch '$inchi_version' does not exist."
+    echo "'$inchi_version' does not exist."
     exit 1
 fi
 


### PR DESCRIPTION
I was getting a [linking error on the inchi-1 binary compiling with MSVC](https://github.com/giallu/InChI/actions/runs/10789122639/job/29921394668) so I decided to rewrite the macro as a regular function. I think the resulting code is more readable but I am not sure if tests cover the functionality it provides so the change is safe.