### PR TITLE
Fix two 'out of bounds' bugs

### DIFF
--- a/INCHI-1-SRC/INCHI_BASE/src/strutil.c
+++ b/INCHI-1-SRC/INCHI_BASE/src/strutil.c
@@ -2062,14 +2062,15 @@ int RemoveInpAtBond( inp_ATOM *atom, int iat, int k )
             }
             if (at->p_parity /* at->valence == MAX_NUM_STEREO_ATOM_NEIGH*/)
             {
-                for (m = 0; m < at->valence; m++)
+                /* p_orig_at_num is a fixed size array of MAX_NUM_STEREO_ATOM_NEIGH (4) elements */
+                for (m = 0; m < at->valence && m < MAX_NUM_STEREO_ATOM_NEIGH; m++)
                 {
                     if (atom[(int) at->neighbor[k]].orig_at_number == at->p_orig_at_num[m])
                     {
                         break;
                     }
                 }
-                if (m < at->valence)
+                if (m < at->valence && m < MAX_NUM_STEREO_ATOM_NEIGH)
                 {
                     at->p_orig_at_num[m] = at->orig_at_number;
                 }
@@ -2435,16 +2436,20 @@ int DisconnectAmmoniumSalt( inp_ATOM *at,
         else
         {
             /* find isotopic H */
-            if (at[iN].num_iso_H[iso_diff])
+            /* num_iso_H has length NUM_H_ISOTOPES; do not access out-of-bounds */
+            if (iso_diff < NUM_H_ISOTOPES && at[iN].num_iso_H[iso_diff])
             {
                 at[iN].num_iso_H[iso_diff] --; /* move implicit isotopic H, atw = 1 */
                 at[iO].num_iso_H[iso_diff] ++;
                 break;
             }
-            else if (num_explicit_H[iso_diff])
+            else
             {
-                nMove_H_iso_diff = iso_diff; /* flag: move explicit isotopic H, atw = 1 */
-                break;
+                if (num_explicit_H[iso_diff])
+                {
+                    nMove_H_iso_diff = iso_diff; /* flag: move explicit isotopic H, atw = 1 */
+                    break;
+                }
             }
         }
     }


### PR DESCRIPTION
We (https://patents.google.com/) encountered some data that triggered out of bounds crashes at these array access sites.

SMILES strings that cause problems prior to this fix:
* `CCCCCCCC/C=C\\CCCCCCCC(=O)OCCN(CCOC(=O)CCCCCCC/C=C\\CCCCCCCC)C(=O)CN(C)C.CCCCCCCC/C=C\\CCCCCCCC(=O)OCCN(CCOC(=O)CCCCCCC/C=C\\CCCCCCCC)C(=O)C[N+](C)(C)C.CCCCCCCCCCCCCC(=O)OCCN(CCOC(=O)CCCCCCCCCCCCC)C(=O)CN(C)C.CCCCCCCCCCCCCC(=O)OCCN(CCOC(=O)CCCCCCCCCCCCC)C(=O)C[N+](C)(C)CCO.COS(C)(=O)=O.OCCBr.[3H]N([3H])([3H])([3H])I.[Br-]`
* `C/[AlH2]1=O/[Si@]2(C)O[Si](C)(C)O[Al@H2]3(C)O[Si@@H]4O[AlH2]5(O[Si@]67O[Si@](C)(O1)O[Si@@](C)(O[Si](C)(C)C)O[Al@H2](C)(O6)O[Si@@]1(C)O[Si@]6(C)O[Si@@](C)(O[Si@@]89O[AlH2]%10%11O[Si@]%12%13O[Al](O[Si@@]%14(C)O[Al@@H2]%15(C)O[Si@@](C)(O4)O[SiH-](O5)(O8)O[Si@](C)(O%15)O[Al@@H2](C)(O%12)O%14)O[Si@]4(C)O[Si@@]5(C)O[AlH2]8(C)O[Si]%12(C)O[Si@](C)(O5)O[Al@H2]5(C)O[Si@@]%14(C)O[AlH2]%15(O[Si@@]%16(C)O[Si](C)(C)O[AlH2](C)(C)O[Si@](C)(O%16)O%14)O[Si@](O[Al@@-]%14%16O[Si@@]%17(C)O[Si@](C)(O[Si@@]%18(C)O[Al@@H2]%19(C)O[Si](C)(C)O[Si](C)(C)O[Si@](O%15)(O%19)O[Al@@H2](C)(O%17)O%18)O[Si@@](C)(O%14)O[Al@H2]%14(C)O[Si@@]%15(C)O[Si@](C)(O[Si@@](C)(O%10)O[Al@H2](C)(O%15)O[Si@@](C)(O%11)O[Al@H2](C)(O6)O9)O[Si@@](O%16)(O[Si@@](O8)(O%13)O4)O%14)(O%12)[OH+]5)O[Al@H2](C)(O7)O1)O[Si@](C)(O2)O3.[Na+].[Na+].[Na+].[Na+].[Na+].[Na+].[Na+].[Na+].[Na+].[Na+].[Na+].[Na+].[Na+].[Na+]`

Thanks!