### PR TITLE
Mem error fixes

### DIFF
--- a/INCHI-1-SRC/INCHI_BASE/src/ichirvr7.c
+++ b/INCHI-1-SRC/INCHI_BASE/src/ichirvr7.c
@@ -1386,6 +1386,9 @@ void FreeStrFromINChI(StrFromINChI* pStruct[INCHI_NUM][TAUT_NUM],
                     inchi_free( pStruct1[k].ti.t_group );
                 }
                 */
+                if ( pStruct1[k].One_ti.t_group ) {
+                    inchi_free( pStruct1[k].One_ti.t_group );
+                }
                 if (pStruct1[k].pXYZ)
                 {
                     inchi_free(pStruct1[k].pXYZ); /* djb-rwth: ui_rr? */
@@ -1516,7 +1519,7 @@ void FreeInpInChI(InpInChI* pOneInput)
 
                         }
                     }
-#endif                    
+#endif
 
                 }
                 inchi_free(pOneInput->pInpInChI[iINChI][j]);

--- a/INCHI-1-SRC/INCHI_BASE/src/mol_fmt3.c
+++ b/INCHI-1-SRC/INCHI_BASE/src/mol_fmt3.c
@@ -1854,6 +1854,7 @@ ret:if (nread < 0)
 int get_V3000_input_line_to_strbuf( INCHI_IOS_STRING *buf,
                                     INCHI_IOSTREAM* inp_stream )
 {
+    const int prefix_len = 7; /* "M  V30 " */
     int old_used, crlf2lf = 1, preserve_lf = 0;
 
     inchi_strbuf_reset( buf );
@@ -1867,13 +1868,13 @@ int get_V3000_input_line_to_strbuf( INCHI_IOS_STRING *buf,
         {
             return -1;
         }
-        if (strncmp( buf->pStr + old_used, "M  V30 ", 7 ))
+        if (strncmp( buf->pStr + old_used, "M  V30 ", prefix_len ))
         {
             return -1;
         }
 
-        memmove((void*)(buf->pStr + old_used), (void*)(buf->pStr + old_used + 7), (long long)buf->nUsedLength - (long long)old_used + 1); /* djb-rwth: cast operators added */
-        buf->nUsedLength -= 7;
+        memmove((void*)(buf->pStr + old_used), (void*)(buf->pStr + old_used + prefix_len), (long long)buf->nUsedLength - (long long)old_used - prefix_len + 1); /* djb-rwth: cast operators added */
+        buf->nUsedLength -= prefix_len;
 
         if (buf->pStr[buf->nUsedLength - 1] != '-')
         {

--- a/INCHI-1-SRC/INCHI_BASE/src/mol_fmt3.c
+++ b/INCHI-1-SRC/INCHI_BASE/src/mol_fmt3.c
@@ -598,6 +598,8 @@ int MolfileV3000ReadSGroup( MOL_FMT_CTAB* ctab,
         remove_one_lf( line );
         if (p && !strcmp( p, "END SGROUP" ))
         {
+            inchi_ios_close( &tmpin );
+
             return 0;
         }
     }
@@ -608,6 +610,8 @@ int MolfileV3000ReadSGroup( MOL_FMT_CTAB* ctab,
     }
 
 err_fin:
+
+    inchi_ios_close( &tmpin );
 
     return err;
 }
@@ -647,6 +651,8 @@ int MolfileV3000Read3DBlock( MOL_FMT_CTAB* ctab,
     goto err_fin;
 
 err_fin:
+
+    inchi_ios_close( &tmpin );
 
     return err;
 }
@@ -855,6 +861,8 @@ int MolfileV3000ReadCollections( MOL_FMT_CTAB* ctab,
     }
 
 err_fin:
+
+    inchi_ios_close( &tmpin );
 
     return err;
 }
@@ -1533,6 +1541,8 @@ int MolfileV3000ReadBondsBlock( MOL_FMT_CTAB* ctab,
     remove_one_lf( line );
 
 err_fin:
+
+    inchi_ios_close( &tmpin );
 
     return err;
 }


### PR DESCRIPTION
This is the PR I mentioned in https://github.com/rdkit/rdkit/pull/8276. It contains fixes for the memory errors (not just leaks) I observed both in RDKit's `testInchi` and also when running the InChI test under `test_executables` as described in https://github.com/IUPAC-InChI/InChI/blob/rwth/INCHI-1-TEST/README.md.

The leak detected in `testInchi` was that `FreeStrFromINChI()` never even tried to free `pStruct1[k].One_ti.t_group`, assigned in `inchitaut.c:4384`.

In `test_executables`, I found 2 issues:

- A buffer overflow when moving the contents of a Mol V3000 line back 7 characters to remove the prefix, which happened because the full length of the line was being moved. Since the moved data from the 7th character in the line, moving the full length of the line was overflowing the end of the buffer by those 7 characters.

- Several leaks in `mol_fmt3.c`, triggered because the return or the error handling of the function never cleared the buffers on the streams.

After these fixes, the InChI code exercised by both RDKit's `testInchi` and local `test_executables` is mem error free.

I hope these are useful!