### PR TITLE
IXA adds two new functions

### DIFF
--- a/INCHI-1-SRC/INCHI_API/libinchi/src/ixa/ixa_builder.c
+++ b/INCHI-1-SRC/INCHI_API/libinchi/src/ixa/ixa_builder.c
@@ -48,7 +48,7 @@
 #include <ctype.h>
 #include <stdlib.h>
 #include <string.h>
-
+#include "mode.h"
 
 #ifdef _WIN32
 #define OPTION_PREFIX  "/"
@@ -2002,7 +2002,16 @@ long INCHI_DECL IXA_INCHIBUILDER_GetOption_Timeout_MilliSeconds( IXA_STATUS_HAND
     return builder->option_WMnumber;
 }
 
+/****************************************************************************/
 
+EXPIMP_TEMPLATE INCHI_API const char* INCHI_DECL IXA_INCHIBUILDER_GetInChIVersion( IXA_BOOL vFullDescription )
+{
+   if (vFullDescription) {
+     return APP_DESCRIPTION;
+   } else {
+     return CURRENT_VER;
+   }
+}
 
 /****************************************************************************/
 const char* INCHI_DECL IXA_INCHIBUILDER_GetInChI( IXA_STATUS_HANDLE hStatus,

--- a/INCHI-1-SRC/INCHI_API/libinchi/src/ixa/ixa_read_inchi.c
+++ b/INCHI-1-SRC/INCHI_API/libinchi/src/ixa/ixa_read_inchi.c
@@ -679,3 +679,71 @@ cleanup:
     FreeStructFromINCHIEx( &output );
 #endif
 }
+
+
+/****************************************************************************/
+void INCHI_DECL IXA_MOL_ReadAuxInfo( IXA_STATUS_HANDLE hStatus,
+                                     IXA_MOL_HANDLE    hMolecule,
+                                     const char*       pAuxInfo, 
+                                     int               bDoNotAddH,
+                                     int               bDiffUnkUndfStereo) {
+    int ret;
+    InchiInpData *inpData;
+    inchi_Input *pInp;
+
+    inpData = malloc(sizeof(*inpData));
+    memset(inpData, 0, sizeof(*inpData));
+    pInp = malloc(sizeof(*pInp));
+    memset(pInp, 0, sizeof(*pInp));
+    inpData->pInp = pInp;
+
+    ret = Get_inchi_Input_FromAuxInfo(pAuxInfo, bDoNotAddH, bDiffUnkUndfStereo, inpData);
+
+    switch(ret) {
+        case inchi_Ret_OKAY:
+        break;
+    case inchi_Ret_WARNING:
+        STATUS_PushMessage( hStatus, IXA_STATUS_WARNING, inpData->szErrMsg);
+        break;
+    case inchi_Ret_ERROR:
+    case inchi_Ret_FATAL:
+    case inchi_Ret_UNKNOWN:
+    case inchi_Ret_BUSY:
+    case inchi_Ret_EOF:
+    case inchi_Ret_SKIP:
+        STATUS_PushMessage( hStatus, IXA_STATUS_ERROR, "Get_inchi_Input_FromAuxInfo: error");
+        goto cleanup;
+    default:
+        STATUS_PushMessage( hStatus, IXA_STATUS_WARNING, "Get_inchi_Input_FromAuxInfo: Unknown return code");
+        break;
+    }
+
+    inchi_Output inchi_output;  
+    ret = GetINCHI(pInp, &inchi_output);
+    switch(ret) {
+        case inchi_Ret_OKAY:
+        break;
+    case inchi_Ret_WARNING:
+        STATUS_PushMessage( hStatus, IXA_STATUS_WARNING, (&inchi_output)->szMessage);
+        break;
+    case inchi_Ret_ERROR:
+    case inchi_Ret_FATAL:
+    case inchi_Ret_UNKNOWN:
+    case inchi_Ret_BUSY:
+    case inchi_Ret_EOF:
+    case inchi_Ret_SKIP:
+        STATUS_PushMessage( hStatus, IXA_STATUS_ERROR, "GetINCHI: error");
+        goto cleanup1;
+    default:
+        STATUS_PushMessage( hStatus, IXA_STATUS_WARNING, "GetINCHI: Unknown return code");
+        break;
+    }
+    IXA_MOL_ReadInChI(hStatus, hMolecule, (&inchi_output)->szInChI);
+
+cleanup1:
+    FreeINCHI(&inchi_output);
+cleanup:
+    Free_inchi_Input(pInp);
+    free(inpData);
+    free(pInp);
+}

--- a/INCHI-1-SRC/INCHI_BASE/src/ixa.h
+++ b/INCHI-1-SRC/INCHI_BASE/src/ixa.h
@@ -610,6 +610,8 @@ extern "C" {
                                                                            IXA_INCHIBUILDER_HANDLE hInChIBuilder,
                                                                            IXA_MOL_HANDLE          hMolecule );
 
+    EXPIMP_TEMPLATE INCHI_API const char* INCHI_DECL IXA_INCHIBUILDER_GetInChIVersion( IXA_BOOL vFullDescription );
+
     EXPIMP_TEMPLATE INCHI_API const char* INCHI_DECL IXA_INCHIBUILDER_GetInChI( IXA_STATUS_HANDLE       hStatus,
                                                                                IXA_INCHIBUILDER_HANDLE hInChIBuilder );
 

--- a/INCHI-1-SRC/INCHI_BASE/src/ixa.h
+++ b/INCHI-1-SRC/INCHI_BASE/src/ixa.h
@@ -287,6 +287,12 @@ extern "C" {
                                                                  IXA_MOL_HANDLE    hMolecule,
                                                                  const char*       pInChI );
 
+    EXPIMP_TEMPLATE INCHI_API void INCHI_DECL IXA_MOL_ReadAuxInfo( IXA_STATUS_HANDLE hStatus,
+                                                                   IXA_MOL_HANDLE    hMolecule,
+                                                                   const char*       pAuxInfo,
+                                                                   int               bDoNotAddH,
+                                                                   int               bDiffUnkUndfStereo );
+
     EXPIMP_TEMPLATE INCHI_API void INCHI_DECL IXA_MOL_SetChiral( IXA_STATUS_HANDLE hStatus,
                                                                  IXA_MOL_HANDLE    hMolecule,
                                                                  IXA_BOOL          vChiral );


### PR DESCRIPTION
This PR creates two new IXA methods:

IXA_INCHIBUILDER_GetInchiVersion

A simple API call that returns either just the version code from CURRENT_VER, such as

    1.07.2

or the full description from APP_DESCRIPTION, such as

    InChI version 1, Software 1.07.2 (inchi-1 executable)

The need for such a method has been discussed. 


IXA_MOL_ReadAuxInfo

The method is based on the inchi_web.c method molfile_from_auxinfo, which returns a stereochemically void MOL file. This method is different, in that it associates an INCHIMOL handle to a full atom, bond, stereo description of the InChI model associated with the auxinfo. 

It is a complement to IXA_MOL_ReadMolFile and IXA_MOL_ReadInChI. Like these two methods, it fills a hMolecule handle with atom, bond, and stereo information. It does this by making three calls:

to Get_inchi_Input_FromAuxInfo, in order to fill an inchi_Input structure,

to GetINCHI, to get the InChI associated with this auxinfo,

to IXA_MOL_ReadInChI, in order to generate an INCHIMOL from this inchi and associate it with the given hMolecule handle.

I chose to place it in ixa_read_inchi.c because it calls IXA_MOL_ReadInChI, but it could certainly be moved to its own file if that is desired. It's a pretty simple function, so I chose not to create a file just for it.  

These methods have been compiled to WASM and tested in JavaScript. See [JNA-InChI/WASM CDK SwingJS Web Demo](https://chemapps.stolaf.edu/inchi/cdk-web-demo/index.html) where, after pressing "continue", a page is shown that indicates the version of InChI from the first of these methods:

![image](https://github.com/user-attachments/assets/6ed3c7bf-4420-4df6-b989-871a02dfd517)

The JavaScript calls for that are:

	  var ptr = module.ccall("IXA_INCHIBUILDER_GetInChIVersion", "number", ["number"], [true]);
	  APP_DESCRIPTION = module.UTF8ToString(ptr);
	  module._free(ptr);	
	  ptr = module.ccall("IXA_INCHIBUILDER_GetInChIVersion", "number", ["number"], [false]);
	  VERSION =module.UTF8ToString(ptr);
	  module._free(ptr);		

The complex ccall and pointer business is needed here just because this method is not yet in JNA-InChI. If it were there, then the 
JavaScript calls could just be:

     APP_DESCRIPTION = IXA.IXA_INCHIBUILDER.GetInChIVersion(true);
     VERSION = IXA.IXA_INCHIBUILDER.GetInChIVersion(false); 

same as in Java.

And for the second test, clicking *or this AuxInfo* just displays benzene using CDK-SwingJS. That code is a bit more involved, but starts with 

	  var ixa = J2S.wasm.jnainchi;
	  var hStatus = ixa.IXA_STATUS_Create();
	  var hMolecule =  ixa.IXA_MOL_Create(hStatus);
	  try {
		  const module = await availableInchiVersions[inchiVersion].module;
		  var inchi = module.ccall("IXA_MOL_ReadAuxInfo", "string", ["number", "number", "string", "number", "number"], [hStatus.peer, hMolecule.peer, auxinfo, bDoNotAddH, bDiffUnkUndfStereo]);
		  processMoleculeHandle(hStatus, hMolecule, null, "", false);
	  } finally {
		  ixa.IXA_MOL_Destroy(null, hMolecule);
		  ixa.IXA_STATUS_Destroy(hStatus);
	  }

where processMoleculeHandle generates the 2D+stereo model using CDK:

      var input = swingjs.CDK.getInchiInputFromMoleculeHandle(hStatus, hMolecule, moreOptions);
      var mol = swingjs.CDK.getCDKMoleculeFromInchiInput(input);
      showStructureImage(mol, isMolfile);

and showStructureImage calls 

     swingjs.CDK.getDataURIFromCDKMolecule(mol)

to create the dataURI from the PNG image that CDK creates that is to be placed on the page for the structure diagram. 

This is a more involved call simply because the method is not already in JNA-InChI. If it were, then the cumbersome ccall call would be just:

		  ixa.IXA_MOL_ReadAuxInfo(hStatus, hMolecule, auxinfo, bDoNotAddH, bDiffUnkUndfStereo);

I admit that I am not sure what the two booleans do; I just copied those from the inchi_web.c call.


Maybe that's too much coding detail to include in a PR, but I thought it might be useful to see how these two methods are used in context. Thank you for your consideration.  I am not a skilled C programmer, so please look the code over carefully and make any adjustments (or tell me to resubmit after fixing) that make these better.

Bob Hanson



