### PR TITLE
Fix stack-buffer-overflow in mark_alt_bonds_and_taut_groups

### DIFF
--- a/INCHI-1-SRC/INCHI_BASE/src/ichinorm.c
+++ b/INCHI-1-SRC/INCHI_BASE/src/ichinorm.c
@@ -781,16 +781,27 @@ int add_inp_ATOM( inp_ATOM *at,
 
 
 /****************************************************************************/
-int mark_arom_bonds( struct tagINCHI_CLOCK *ic, struct tagCANON_GLOBALS *pCG, inp_ATOM *at, int num_atoms )
+int mark_arom_bonds(struct tagINCHI_CLOCK *ic, struct tagCANON_GLOBALS *pCG, inp_ATOM *at, int num_atoms)
 {
     INCHI_MODE bTautFlags = 0, bTautFlagsDone = 0;
     inp_ATOM *at_fixed_bonds_out = NULL;
     T_GROUP_INFO *t_group_info = NULL;
     int ret;
 
-    ret = mark_alt_bonds_and_taut_groups( ic, pCG, at, at_fixed_bonds_out, num_atoms,
-                                          NULL,
-                                          t_group_info, &bTautFlags, &bTautFlagsDone, 0, NULL );
+    if (num_atoms <= 0 || at == NULL) {
+        return -1;
+    }
+
+    at_fixed_bonds_out = (inp_ATOM *)calloc(num_atoms, sizeof(inp_ATOM));
+    if (!at_fixed_bonds_out) {
+        return -1;
+    }
+
+    ret = mark_alt_bonds_and_taut_groups(ic, pCG, at, at_fixed_bonds_out, num_atoms,
+                                         NULL,
+                                         t_group_info, &bTautFlags, &bTautFlagsDone, 0, NULL);
+
+    free(at_fixed_bonds_out); // Clean up
 
     return ret;
 }


### PR DESCRIPTION
This PR addresses a stack-buffer-overflow in the mark_alt_bonds_and_taut_groups function by allocating memory for at_fixed_bonds_out. Previously, the pointer was null, leading to potential memory corruption. 
this fix ensures safe memory access and prevents undefined behavior.
issue link: https://issues.oss-fuzz.com/issues/390646660