### PR TITLE
avoid out-of-bound access in mystrncpy()

### DIFF
--- a/INCHI-1-SRC/INCHI_BASE/src/util.c
+++ b/INCHI-1-SRC/INCHI_BASE/src/util.c
@@ -1719,12 +1719,22 @@ int mystrncpy(char *target, const char *source, unsigned maxlen)
         return 0;
     }
 
-    if ((p = (const char*)memchr(source, 0, maxlen))) /* djb-rwth: addressing LLVM warning */
-    {    /* maxlen does not include the found zero termination */
-        len = (int) (p - source);
+    /* Find actual source length first to limit memchr search */
+    unsigned source_len = (unsigned)strlen(source);
+
+    if (source_len < maxlen)
+    {
+        /* Source is shorter than maxlen, use actual source length */
+        len = source_len;
+    }
+    else if ((p = (const char*)memchr(source, 0, maxlen)))
+    {
+        /* maxlen does not include the found zero termination */
+        len = (unsigned)(p - source);
     }
     else
-    { /*  reduced length does not include one more byte for zero termination */
+    {
+        /* reduced length does not include one more byte for zero termination */
         len = maxlen - 1;
     }
 


### PR DESCRIPTION
the mystrncpy() function as is written now:

https://github.com/IUPAC-InChI/InChI/blob/c3eed491986ffc43082cfb373173af52dba45c99/INCHI-1-SRC/INCHI_BASE/src/util.c#L1712-L1740

will read past the end of the source string when used like this:

https://github.com/IUPAC-InChI/InChI/blob/c3eed491986ffc43082cfb373173af52dba45c99/INCHI-1-SRC/INCHI_API/libinchi/src/inchi_dll.c#L1570

for this reason, I propose checking first if the source string is shorter than maxlen, and act appropriately

by the way, trying to be smarter than the standard library is rarely a good idea, I'd see if it's possible to just use strncpy or at leasemake mystrncpy a wrapper around it.