### PR TITLE
Remove non-existent function base26_checksum from header

### DIFF
--- a/INCHI-1-SRC/INCHI_BASE/src/ikey_base26.h
+++ b/INCHI-1-SRC/INCHI_BASE/src/ikey_base26.h
@@ -78,8 +78,6 @@ extern "C" {
     const char* base26_dublet_for_bits_28_to_36( unsigned char *a );
     /*    Get dublet (bits 56..64)    */
     const char* base26_dublet_for_bits_56_to_64( unsigned char *a );
-    /*    Calculate check character for the string.    */
-    const char base26_checksum( const char *str );
     /*    Get hash extension in hexadecimal representation for the major block.
         Len(extension) = 256 - 65 = 191 bit.                                */
     void get_xtra_hash_major_hex( const unsigned char *a, char* szXtra );


### PR DESCRIPTION
The base26_checksum implementation was removed... a long time ago. It does not belong in a header, or anything people would read to understand the structure of the current project.