### PR TITLE
Make sure Create_INChI always deallocates t_group

### DIFF
--- a/INCHI-1-SRC/INCHI_BASE/src/ichimake.c
+++ b/INCHI-1-SRC/INCHI_BASE/src/ichimake.c
@@ -4537,6 +4537,10 @@ exit_function:
         /* free_t_group_info(t_group_info); */
         if (t_group_info) /* djb-rwth: fixing oss-fuzz issue #42537161/70475 */
         {
+            if (t_group_info->t_group)
+            {
+                inchi_free(t_group_info->t_group);
+            }
             if (t_group_info->nEndpointAtomNumber)
             {
                 inchi_free(t_group_info->nEndpointAtomNumber);


### PR DESCRIPTION
This PR adds deallocation of `t_group` to a `Create_INChI` path where it was missing.

Fixes #201 

Note: [this commented call](https://github.com/IUPAC-InChI/InChI/blob/3a730b50365b2d70a00bda66178cc8bd9043ecd4/INCHI-1-SRC/INCHI_BASE/src/ichimake.c#L4537) would fix this issue as well, but I'm assuming that should stay commented.