### PR TITLE
fix GHI# 206

### DIFF
--- a/INCHI-1-SRC/INCHI_BASE/src/runichi.c
+++ b/INCHI-1-SRC/INCHI_BASE/src/runichi.c
@@ -325,6 +325,13 @@ int ProcessOneStructure(INCHI_CLOCK* ic,
             printf("\n");
         }*/
 
+        /* Preserve SDF output in Molecular Inorganics mode if requested */
+        ret1 = OrigAtData_SaveMolfile(orig_inp_data, sd, ip, num_inp, out_file);
+        if (ret1)
+        {
+            goto exit_function;
+        }
+
         /*printf("Molecular inorganics preprocessing completed successfully.\n");*/
         nRet1 = CreateOneStructureINChI(pCG, ic, sd, ip, szTitle,
             pINChI, pINChI_Aux, INCHI_BAS,
@@ -367,6 +374,16 @@ int ProcessOneStructure(INCHI_CLOCK* ic,
             maxINChI = 1;
         }
 
+        /*
+         * InChI is already generated via the Molecular Inorganics-specific path.
+         * Skip the standard structure-generation path to prevent duplicate
+         * CreateOneStructureINChI() calls, which previously caused redundant
+         * allocations and AddressSanitizer-reported memory leaks.
+         *
+         * Note: pOrigStruct intentionally remains NULL in Molecular Inorganics
+         * mode because OrigAtData_StoreNativeInput() is bypassed here; therefore
+         * AuxInfo reversibility layers (/rA, /rB, /rC) are not generated.
+         */
         goto after_structure_generation;
     }
 

--- a/INCHI-1-SRC/INCHI_BASE/src/runichi.c
+++ b/INCHI-1-SRC/INCHI_BASE/src/runichi.c
@@ -361,6 +361,13 @@ int ProcessOneStructure(INCHI_CLOCK* ic,
                 maxINChI = 2;  /* Update to indicate reconnected InChI has been generated */
             }
         }
+
+        else if (nRet != _IS_FATAL && nRet != _IS_ERROR)
+        {
+            maxINChI = 1;
+        }
+
+        goto after_structure_generation;
     }
 
 
@@ -482,6 +489,8 @@ int ProcessOneStructure(INCHI_CLOCK* ic,
             maxINChI = 2;
         }
     }
+
+after_structure_generation:
 
     if ( nRet != _IS_FATAL && nRet != _IS_ERROR )
     {
@@ -1846,7 +1855,7 @@ int CreateOneComponentINChI(CANON_GLOBALS* pCG,
 #endif
 
     InchiTimeGet( &ulTStart );
-  
+
     bOrigCoord =
         !(ip->bINChIOutputOptions & (INCHI_OUT_NO_AUX_INFO | INCHI_OUT_SHORT_AUX_INFO));
 


### PR DESCRIPTION
This PR fixes memory leaks in the Molecular Inorganics pipeline that were exposed by unit tests as described in the [GHI#206](https://github.com/IUPAC-InChI/InChI/issues/206). 

The fix controls the flow in `ProcessOneStructure()` to prevent duplicate INChI generation when Molecular Inorganics mode is enabled.