### PR TITLE
Pin GitHub Actions dependencies

### DIFF
--- a/.github/actions/invariance_tests/action.yml
+++ b/.github/actions/invariance_tests/action.yml
@@ -25,7 +25,7 @@ runs:
 
     - name: Upload invariance test results
       if: ${{ !cancelled() }}
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: ${{ inputs.artifact-name }}
         path: |

--- a/.github/actions/regression_tests/action.yml
+++ b/.github/actions/regression_tests/action.yml
@@ -29,7 +29,7 @@ runs:
 
     - name: Upload regression test results
       if: ${{ !cancelled() }}
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: ${{ inputs.artifact-name }}
         path: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     container: python:3.12
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - id: setup
         run: ./.devcontainer/post_create_commands.sh
@@ -50,7 +50,7 @@ jobs:
 
       # We need to install git before checking out the repository.
       # Otherwise, the repository will be downloaded using the GitHub REST API instead of git.
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Show Python version
         run: |

--- a/.github/workflows/deploy_pages.yml
+++ b/.github/workflows/deploy_pages.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Install build dependencies
         run: |
@@ -70,9 +70,9 @@ jobs:
           </html>
           EOF
 
-      - uses: actions/configure-pages@v6
+      - uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
 
-      - uses: actions/upload-pages-artifact@v5
+      - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: site_root
           retention-days: 30
@@ -89,4 +89,4 @@ jobs:
       id-token: write
     steps:
       - id: deployment
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
     outputs:
       matrix: ${{ steps.define_matrix.outputs.matrix }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Verify build matrix
         # The build matrix is used to interpolate commands and inputs throughout the remainder of the workflow.
@@ -43,9 +43,9 @@ jobs:
       RELEASE_DIR: inchi-${{ matrix.slug }}-${{ github.sha }}
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: '3.12'
 
@@ -79,7 +79,7 @@ jobs:
           shell: ${{ runner.os == 'Windows' && 'pwsh' || 'bash' }}
 
       - name: Upload CMake configurations
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: CMake-configurations-${{ matrix.slug }}-${{ github.sha }}
           path: |
@@ -94,7 +94,7 @@ jobs:
           cp ${{ matrix.main_path }} ${{ env.RELEASE_DIR }}
 
       - id: upload-unsigned-artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ env.RELEASE_DIR }}
           path: ${{ env.RELEASE_DIR }}
@@ -111,7 +111,7 @@ jobs:
           wait-for-completion: true
           output-artifact-directory: ${{ env.RELEASE_DIR }}-signed
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: runner.os == 'Windows'
         with:
           name: ${{ env.RELEASE_DIR }}-signed
@@ -126,14 +126,14 @@ jobs:
 
     steps:
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         # git repository needs to be checked out (including tags, hence `fetch-depth: 0`),
         # otherwise the `--verify-tag` flag to `gh release create` fails.
         with:
           fetch-depth: 0
 
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.1.0
         with:
           path: release_artifacts
           pattern: inchi-*
@@ -142,7 +142,7 @@ jobs:
         run: zip -r release_artifacts.zip release_artifacts
 
       - name: Download CMake configurations
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.1.0
         with:
           path: cmake_configurations
           pattern: CMake-configurations-*

--- a/.github/workflows/test_coverage_regression.yml
+++ b/.github/workflows/test_coverage_regression.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Install build dependencies
         run: |
@@ -146,7 +146,7 @@ jobs:
           echo "Coverage OK: lines ${PR_LINES}% >= base ${BASE_LINES}%, branches ${PR_BRANCHES}% >= base ${BASE_BRANCHES}%"
 
       - name: Upload coverage reports
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()
         with:
           name: coverage-reports-${{ github.run_id }}
@@ -155,7 +155,7 @@ jobs:
 
       - name: Post sticky PR comment (same-repo only)
         if: always() && github.event.pull_request.head.repo.full_name == github.repository
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const fs = require('fs');


### PR DESCRIPTION
GitHub actions does not have a principled approach to locking versions, which poses both a security risk to supply chain attacks, and more often, annoyance to developers when things change.

This PR runs pinact (https://github.com/suzuki-shunsuke/pinact) to pin the GitHub Actions components to the specific commit corresponding to each version. This isn't perfect for security either, but it's at least a good step