### PR TITLE
build(deps): bump pytest to 9.0.3 (CVE-2025-71176)

### DIFF
--- a/INCHI-1-TEST/pyproject.toml
+++ b/INCHI-1-TEST/pyproject.toml
@@ -2,7 +2,7 @@
 name = "inchi_tests"
 version = "1.0.0"
 requires-python = ">=3.11,<3.13"
-dependencies = ["pydantic == 2.11.5", "pytest == 8.3.5"]
+dependencies = ["pydantic == 2.11.5", "pytest == 9.0.3"]
 
 [project.optional-dependencies]
 # FIXME: Don't force numpy major version as soon as https://github.com/IUPAC-InChI/InChI/issues/35 is resolved.


### PR DESCRIPTION
## Summary

- Bump `pytest` from `8.3.5` to `9.0.3` in `INCHI-1-TEST/pyproject.toml` to resolve a Dependabot security alert.

## Vulnerability

- **CVE-2025-71176 / GHSA-6w46-j5rx-g56g** (Medium, CVSS 6.8) — pytest `< 9.0.3` uses a predictable `/tmp/pytest-of-{user}` temp path (CWE-379). A local attacker on a shared host could squat the path to cause DoS or potential privilege escalation.
- pytest is a **test-only** dependency (drives the `inchi-1` CLI tests), so the shipped `inchi-1` / `libinchi` artifacts are unaffected. This bump exists to clear the alert and keep dev/CI tooling current.

## Verification

`8.3.5 -> 9.0.3` is a major-version jump, so I rebuilt and ran the pytest-collected suites against the new version:

```
pytest INCHI-1-TEST/tests/test_executable INCHI-1-TEST/tests/test_meta
=> 22 passed, 4 skipped, 10 xfailed   (exit 0)
```

No deprecations or collection errors under pytest 9. The `test_library` harnesses (multithreading/regression/invariance) are invoked as plain `python` scripts rather than through pytest, so they are unaffected by the version change.

## Type of change

- [x] build — dependency/security bump (no release)