### PR TITLE
OSS-Fuzz: Move fuzzers upstream and add new fuzzers targets molfile processing

### DIFF
--- a/INCHI-1-FUZZ/build.sh
+++ b/INCHI-1-FUZZ/build.sh
@@ -1,0 +1,28 @@
+# Builds the OSS-Fuzz fuzz targets for InChI. Driven by the OSS-Fuzz toolchain
+# environment ($CC/$CXX/$CFLAGS/$CXXFLAGS/$LIB_FUZZING_ENGINE/$OUT/$WORK). Every
+# ossfuzz/*_fuzzer.c is compiled and linked against the InChI library.
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(dirname "$HERE")"
+
+cd "$ROOT/INCHI-1-SRC"
+
+# Compile the library sources (exclude ichimain.c, the standalone CLI main).
+SRC_FILES=$(ls INCHI_BASE/src/*.c INCHI_API/libinchi/src/*.c INCHI_API/libinchi/src/ixa/*.c | grep -v ichimain.c)
+$CC $CFLAGS -Wno-everything -DTARGET_API_LIB -c $SRC_FILES
+ar rcs "$WORK/libinchi.a" *.o
+
+# Compile + link each fuzz target.
+for fuzzer in "$HERE"/*_fuzzer.c; do
+  fuzzer_basename=$(basename -s .c "$fuzzer")
+
+  $CC $CFLAGS \
+      -I INCHI_BASE/src/ \
+      -I INCHI_API/libinchi/src/ \
+      -I INCHI_API/libinchi/src/ixa/ \
+      "$fuzzer" -c -o "${fuzzer_basename}.o"
+
+  $CXX $CXXFLAGS \
+      "${fuzzer_basename}.o" -o "$OUT/$fuzzer_basename" \
+      $LIB_FUZZING_ENGINE "$WORK/libinchi.a"
+done

--- a/INCHI-1-FUZZ/inchi_input_fuzzer.c
+++ b/INCHI-1-FUZZ/inchi_input_fuzzer.c
@@ -1,0 +1,56 @@
+// Copyright 2020 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "inchi_api.h"
+
+// Define the maximum value for size_t. We return if the fuzzing input is equal
+// to kSizeMax because appending the null-terminator to the InChI buffer would
+// cause wraparound, thereby initializing the buffer to size 0.
+static const size_t kSizeMax = (size_t)-1;
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+
+  if (size == kSizeMax)
+    return 0;
+
+  char *szINCHISource = malloc(sizeof(char) * (size + 1));
+  memcpy(szINCHISource, data, size);
+  szINCHISource[size] = '\0'; // InChI string must be null-terminated
+
+  // Buffer lengths taken from InChI API reference, located at
+  // https://www.inchi-trust.org/download/104/InChI_API_Reference.pdf, page 24
+  char szINCHIKey[28], szXtra1[65], szXtra2[65];
+  GetINCHIKeyFromINCHI(szINCHISource, 0, 0, szINCHIKey, szXtra1, szXtra2);
+
+  inchi_InputINCHI inpInChI;
+  inpInChI.szInChI = szINCHISource;
+  inpInChI.szOptions = NULL;
+
+  inchi_Output out;
+  GetINCHIfromINCHI(&inpInChI, &out);
+
+  inchi_OutputStruct outStruct;
+  GetStructFromINCHI(&inpInChI, &outStruct);
+
+  free(szINCHISource);
+  FreeINCHI(&out);
+  FreeStructFromINCHI(&outStruct);
+
+  return 0;
+}

--- a/INCHI-1-FUZZ/molfile_fuzzer.c
+++ b/INCHI-1-FUZZ/molfile_fuzzer.c
@@ -1,0 +1,50 @@
+// Copyright 2026 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Molfile/SDfile text parser fuzzer.
+//
+// inchi_input_fuzzer feeds an InChI *string* (the InChI->structure direction),
+// leaving the MOLfile/SDfile text reader (mol_fmt*.c / readinch.c) at 0%.
+// MakeINCHIFromMolfileText parses a Molfile supplied as text and builds an
+// InChI from it, exercising the V2000/V3000 connection-table reader directly.
+
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "inchi_api.h"
+
+static const size_t kSizeMax = (size_t)-1;
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+  if (size == 0 || size == kSizeMax)
+    return 0;
+
+  char *moltext = malloc(size + 1);
+  if (!moltext)
+    return 0;
+  memcpy(moltext, data, size);
+  moltext[size] = '\0'; // Molfile text must be NUL-terminated
+
+  char options[] = ""; // non-const buffer (API takes char*)
+
+  inchi_Output out;
+  memset(&out, 0, sizeof(out));
+  MakeINCHIFromMolfileText(moltext, options, &out);
+  FreeINCHI(&out);
+
+  free(moltext);
+  return 0;
+}


### PR DESCRIPTION
This PR move all the OSS-Fuzz fuzzers to the upstream storage for easier management. This PR also adds a new OSS-Fuzz fuzzer targets molfile processing. This PR works together with OSS-Fuzz (https://github.com/google/oss-fuzz/pull/15803) to accommodate the moving of fuzzers upstream.

Of course, this is only a suggestion. If the maintainers would prefer the fuzzers to remain in OSS-Fuzz, I am happy to keep the current setup and to ping the relevant maintainers for review whenever I add new fuzzers later in the process.

Thank you for considering this, and I would welcome any feedback on the preferred approach.