### PR TITLE
feat: kekulize aromatic ions, delocalized ring anions, and connected organometallics

### DIFF
--- a/INCHI-1-SRC/INCHI_BASE/src/aromaticity.c
+++ b/INCHI-1-SRC/INCHI_BASE/src/aromaticity.c
@@ -67,6 +67,25 @@ int fix_aromatic_oxygen_and_sulfur( inp_ATOM *atom )
 
 
 /****************************************************************************/
+int huckel_pi_contribution( inp_ATOM *at, int i )
+{
+    if (at[i].charge > 0)
+    {
+        return 0; /* cationic center: empty p orbital */
+    }
+    if (at[i].charge < 0)
+    {
+        return 2; /* anionic center: in-ring lone pair */
+    }
+    if (at[i].radical == RADICAL_DOUBLET)
+    {
+        return 1; /* radical center: singly occupied MO */
+    }
+    return 1;     /* ordinary conjugated atom: one ring double bond */
+}
+
+
+/****************************************************************************/
 int check_arom_chain( inp_ATOM *at,
                       int cur /* first*/,
                       int from,

--- a/INCHI-1-SRC/INCHI_BASE/src/aromaticity.c
+++ b/INCHI-1-SRC/INCHI_BASE/src/aromaticity.c
@@ -86,6 +86,33 @@ int huckel_pi_contribution( inp_ATOM *at, int i )
 
 
 /****************************************************************************/
+/* Number of atom i's neighbors that are metal atoms. */
+static int count_metal_neighbors( inp_ATOM *at, int i )
+{
+    int k, n = 0;
+    for (k = 0; k < at[i].valence; k++)
+    {
+        if (is_el_a_metal( at[at[i].neighbor[k]].el_number ))
+        {
+            n++;
+        }
+    }
+    return n;
+}
+
+/****************************************************************************/
+int is_aromatic_electron_source( inp_ATOM *at, int i )
+{
+    int ring_coordination = (int) at[i].valence - count_metal_neighbors( at, i );
+
+    return ring_coordination == 2 &&
+           at[i].num_H == 0 &&
+           at[i].chem_bonds_valence > at[i].valence &&
+           ( at[i].charge != 0 || at[i].radical == RADICAL_DOUBLET );
+}
+
+
+/****************************************************************************/
 int check_arom_chain( inp_ATOM *at,
                       int cur /* first*/,
                       int from,

--- a/INCHI-1-SRC/INCHI_BASE/src/aromaticity.c
+++ b/INCHI-1-SRC/INCHI_BASE/src/aromaticity.c
@@ -113,6 +113,23 @@ int is_aromatic_electron_source( inp_ATOM *at, int i )
 
 
 /****************************************************************************/
+int relax_aromatic_electron_sources( inp_ATOM *at, int num_atoms )
+{
+    int i, num_relaxed = 0;
+    for (i = 0; i < num_atoms; i++)
+    {
+        if (is_aromatic_electron_source( at, i ))
+        {
+            at[i].chem_bonds_valence--;
+            at[i].num_H++;
+            num_relaxed++;
+        }
+    }
+    return num_relaxed;
+}
+
+
+/****************************************************************************/
 int check_arom_chain( inp_ATOM *at,
                       int cur /* first*/,
                       int from,

--- a/INCHI-1-SRC/INCHI_BASE/src/aromaticity.h
+++ b/INCHI-1-SRC/INCHI_BASE/src/aromaticity.h
@@ -176,6 +176,22 @@ int check_arom_chain( inp_ATOM *at, int cur, int from, int last, int len );
 int replace_arom_bonds( inp_ATOM *at, int num_atoms, inp_ATOM *at2, int num_atoms2 );
 
 /**
+ * @brief Relax Hückel electron-source ring atoms so an odd aromatic ring kekulizes.
+ *
+ * For every atom for which @c is_aromatic_electron_source is true, moves one
+ * valence unit from an assumed ring double bond to an implicit hydrogen
+ * (@c chem_bonds_valence-- paired with @c num_H++). Total valence and formula
+ * are preserved; charge and radical state are untouched. Intended to run only
+ * after the balanced-network kekulizer returns @c BNS_ALTBOND_ERR; the caller
+ * rebuilds the network and retries the conversion once.
+ *
+ * @param at        Atom array (modified in place).
+ * @param num_atoms Number of atoms in @p at.
+ * @return Number of atoms relaxed (0 if none matched).
+ */
+int relax_aromatic_electron_sources( inp_ATOM *at, int num_atoms );
+
+/**
  * @brief Mark alternating (aromatic) bonds via the balanced-network kekulizer.
  *
  * Thin convenience wrapper around mark_alt_bonds_and_taut_groups() invoked

--- a/INCHI-1-SRC/INCHI_BASE/src/aromaticity.h
+++ b/INCHI-1-SRC/INCHI_BASE/src/aromaticity.h
@@ -82,6 +82,21 @@ struct tagCANON_GLOBALS;
 int fix_aromatic_oxygen_and_sulfur( inp_ATOM *atom );
 
 /**
+ * @brief π-electron contribution of a ring atom to its conjugated system.
+ *
+ * Hückel counting for the electron-source cases this module handles: a cationic
+ * center donates 0 (empty p orbital), an anionic center donates 2 (in-ring lone
+ * pair), a doublet-radical center donates 1 (SOMO), and any other neutral atom
+ * donates 1 (its share of a ring double bond). Heteroatom-specific lone-pair
+ * rules (pyridine/pyrrole/furan) are deferred to a later increment.
+ *
+ * @param at Atom array.
+ * @param i  Index of the ring atom.
+ * @return Number of π electrons the atom donates (0, 1, or 2).
+ */
+int huckel_pi_contribution( inp_ATOM *at, int i );
+
+/**
  * @brief Test whether an atom is an unsaturated but non-aromatic carbon.
  *
  * True when @c at[i] is a neutral, non-radical carbon of total valence 4 that

--- a/INCHI-1-SRC/INCHI_BASE/src/aromaticity.h
+++ b/INCHI-1-SRC/INCHI_BASE/src/aromaticity.h
@@ -89,6 +89,7 @@ int fix_aromatic_oxygen_and_sulfur( inp_ATOM *atom );
  * pair), a doublet-radical center donates 1 (SOMO), and any other neutral atom
  * donates 1 (its share of a ring double bond). Heteroatom-specific lone-pair
  * rules (pyridine/pyrrole/furan) are deferred to a later increment.
+ * It is not yet invoked by the engine; it documents the π-electron rules for the deferred heteroaromatic increment and is currently exercised only by unit tests.
  *
  * @param at Atom array.
  * @param i  Index of the ring atom.

--- a/INCHI-1-SRC/INCHI_BASE/src/aromaticity.h
+++ b/INCHI-1-SRC/INCHI_BASE/src/aromaticity.h
@@ -97,6 +97,23 @@ int fix_aromatic_oxygen_and_sulfur( inp_ATOM *atom );
 int huckel_pi_contribution( inp_ATOM *at, int i );
 
 /**
+ * @brief Test whether a ring atom is a Hückel electron source needing relaxation.
+ *
+ * True when atom @p i cannot carry a localized ring double bond and therefore
+ * blocks kekulization of an odd aromatic ring: its ring coordination
+ * (@c valence minus the number of metal neighbors) is 2, it has no implicit H,
+ * its @c chem_bonds_valence exceeds its @c valence (spare valence left by the
+ * unresolved aromatic system), and it is either charged or a doublet radical.
+ * Metal neighbors are counted, not excluded, so connected organometallic rings
+ * (e.g. ferrocene Cp) qualify.
+ *
+ * @param at Atom array.
+ * @param i  Index of the candidate ring atom.
+ * @return 1 if @p i is an electron source to relax; 0 otherwise.
+ */
+int is_aromatic_electron_source( inp_ATOM *at, int i );
+
+/**
  * @brief Test whether an atom is an unsaturated but non-aromatic carbon.
  *
  * True when @c at[i] is a neutral, non-radical carbon of total valence 4 that

--- a/INCHI-1-SRC/INCHI_BASE/src/ichi_bns.c
+++ b/INCHI-1-SRC/INCHI_BASE/src/ichi_bns.c
@@ -5278,6 +5278,14 @@ int mark_alt_bonds_and_taut_groups( struct tagINCHI_CLOCK   *ic,
 #endif
     int at_prot;  /* moved from below 2024-09-01 DT */
 
+    /* Issue #154: snapshot of the pre-search atom state (with original type-4
+       BOND_ALTERN ring bonds) taken when an unresolved aromatic electron source
+       is present, so the Hückel-relaxation retry can restart from flexible
+       aromatic bonds instead of the concrete single/double bonds the first
+       search commits via SetBondsFromBnStructFlow. */
+    inp_ATOM *at_arom_snapshot = NULL;
+    int       i_src, has_arom_electron_source = 0;
+
     nChanges = 0;
     bError = 0;
 
@@ -5380,6 +5388,30 @@ int mark_alt_bonds_and_taut_groups( struct tagINCHI_CLOCK   *ic,
     again:
     */
 
+    /* Issue #154: if the structure carries an unresolved aromatic electron source
+       (a charged or doublet-radical ring atom whose chem_bonds_valence exceeds its
+       valence), snapshot the pre-search atom state now -- while the ring bonds are
+       still flexible type-4 BOND_ALTERN. AllocateAndInitBnStruct below and the first
+       kekulization overwrite at[].bond_type with concrete single/double bonds, so
+       this snapshot is the only way to restart the relaxation retry from flexible
+       bonds. Structures without such a source never allocate the snapshot. */
+    for (i_src = 0; i_src < num_atoms; i_src++)
+    {
+        if (is_aromatic_electron_source( at, i_src ))
+        {
+            has_arom_electron_source = 1;
+            break;
+        }
+    }
+    if (has_arom_electron_source)
+    {
+        at_arom_snapshot = (inp_ATOM *) inchi_calloc( num_atoms, sizeof( at_arom_snapshot[0] ) );
+        if (at_arom_snapshot)
+        {
+            memcpy( at_arom_snapshot, at, num_atoms * sizeof( at_arom_snapshot[0] ) );
+        }
+    }
+
     /* Allocate Balanced Network Data Strucures; replace Alternating bonds with Single */
     if (( pBNS = AllocateAndInitBnStruct( at, num_atoms,
                                           BNS_ADD_ATOMS, BNS_ADD_EDGES,
@@ -5440,13 +5472,43 @@ int mark_alt_bonds_and_taut_groups( struct tagINCHI_CLOCK   *ic,
                BNS_ALTBOND_ERR. Relax those sources (see aromaticity.c), rebuild the
                network, and retry the conversion once. Structures that already
                kekulize never reach this path, so existing InChIs are unaffected. */
-            if (ret == BNS_ALTBOND_ERR &&
-                 relax_aromatic_electron_sources( at, num_atoms ) > 0)
+            if (ret == BNS_ALTBOND_ERR && at_arom_snapshot)
             {
-                ret = ReInitBnStruct( pBNS, at, num_atoms, 1 );
-                if (!IS_BNS_ERROR( ret ))
+                /* Restore the pre-search atom state (flexible type-4 ring bonds and
+                   the original valences/charges) that the failed first kekulization
+                   overwrote, then relax the aromatic electron sources on that clean
+                   state. Relaxation moves one valence unit of each source from a ring
+                   double bond to an implicit H so the odd aromatic ring gains a
+                   perfect matching. Because the vertex st-capacities are frozen at
+                   AllocateAndInitBnStruct time (MAX_AT_FLOW = chem_bonds_valence -
+                   valence), the network must be rebuilt from scratch -- ReInitBnStruct
+                   alone would keep the stale caps and demand a double bond at the
+                   relaxed atom. */
+                memcpy( at, at_arom_snapshot, num_atoms * sizeof( at_arom_snapshot[0] ) );
+                if (relax_aromatic_electron_sources( at, num_atoms ) > 0)
                 {
-                    ret = BnsAdjustFlowBondsRad( pBNS, pBD, at, num_atoms );
+                    pBNS = DeAllocateBnStruct( pBNS );
+                    pBD  = DeAllocateBnData( pBD );
+                    if (( pBNS = AllocateAndInitBnStruct( at, num_atoms,
+                                                          BNS_ADD_ATOMS, BNS_ADD_EDGES,
+                                                          max_altp, &num_changed_bonds ) )
+                         &&
+                         ( pBD = AllocateAndInitBnData( pBNS->max_vertices ) ))
+                    {
+                        pBNS->pbTautFlags = pbTautFlags;
+                        pBNS->pbTautFlagsDone = pbTautFlagsDone;
+                        pBNS->ulTimeOutTime = ulTimeOutTime;
+                        pBNS->ic = ic;
+#if ( BNS_PROTECT_FROM_TAUT == 1 )
+                        SetForbiddenEdges( pBNS, at, num_atoms, BNS_EDGE_FORBIDDEN_MASK, nebend, ebend );
+#endif
+                        ret = BnsAdjustFlowBondsRad( pBNS, pBD, at, num_atoms );
+                    }
+                    else
+                    {
+                        bError = BNS_OUT_OF_RAM;
+                        goto exit_function;
+                    }
                 }
             }
             if (IS_BNS_ERROR( ret ))
@@ -5957,6 +6019,10 @@ exit_function:
     /* djb-rwth: ignoring LLVM warning: variables used to store functions return values */
     pBNS = DeAllocateBnStruct(pBNS);
     pBD = DeAllocateBnData(pBD);
+    if (at_arom_snapshot)
+    {
+        inchi_free( at_arom_snapshot );
+    }
     /*#if ( MOVE_CHARGES == 1 )*/
     if (c_group_info)
     {

--- a/INCHI-1-SRC/INCHI_BASE/src/ichi_bns.c
+++ b/INCHI-1-SRC/INCHI_BASE/src/ichi_bns.c
@@ -58,6 +58,7 @@ Normalization related procedures
 #include "util.h"
 #include "ichister.h"
 #include "ichi_bns.h"
+#include "aromaticity.h"
 
 #include "bcf_s.h"
 
@@ -5428,8 +5429,31 @@ int mark_alt_bonds_and_taut_groups( struct tagINCHI_CLOCK   *ic,
         /* (here pair(s) of radicals could have disappeared from the atoms) */
         if (IS_BNS_ERROR( ret ))
         {
-            bError = ret;
-            goto exit_function;
+            /* Issue #154/#82: aromatic carbon ions (tropylium C7H7+, cyclopropenyl
+               C3H3+, cyclopentadienyl C5H5-), neutral odd-ring radicals (C5H5.),
+               and connected organometallic aromatics (ferrocene Cp under
+               MolecularInorganics) cannot be kekulized while every aromatic ring
+               atom is required to carry a localized double bond: the electron-
+               source atom contributes to the pi system via an empty orbital
+               (cation), lone pair (anion) or SOMO (radical), not a double bond, so
+               no perfect matching exists and BnsAdjustFlowBondsRad fails with
+               BNS_ALTBOND_ERR. Relax those sources (see aromaticity.c), rebuild the
+               network, and retry the conversion once. Structures that already
+               kekulize never reach this path, so existing InChIs are unaffected. */
+            if (ret == BNS_ALTBOND_ERR &&
+                 relax_aromatic_electron_sources( at, num_atoms ) > 0)
+            {
+                ret = ReInitBnStruct( pBNS, at, num_atoms, 1 );
+                if (!IS_BNS_ERROR( ret ))
+                {
+                    ret = BnsAdjustFlowBondsRad( pBNS, pBD, at, num_atoms );
+                }
+            }
+            if (IS_BNS_ERROR( ret ))
+            {
+                bError = ret;
+                goto exit_function;
+            }
         }
         pBNS->tot_st_flow += 2 * ret;
 

--- a/INCHI-1-SRC/INCHI_BASE/src/ichi_bns.c
+++ b/INCHI-1-SRC/INCHI_BASE/src/ichi_bns.c
@@ -5410,6 +5410,11 @@ int mark_alt_bonds_and_taut_groups( struct tagINCHI_CLOCK   *ic,
         {
             memcpy( at_arom_snapshot, at, num_atoms * sizeof( at_arom_snapshot[0] ) );
         }
+        else
+        {
+            bError = BNS_OUT_OF_RAM; /* consistent with the other allocation sites */
+            goto exit_function;
+        }
     }
 
     /* Allocate Balanced Network Data Strucures; replace Alternating bonds with Single */
@@ -5503,6 +5508,28 @@ int mark_alt_bonds_and_taut_groups( struct tagINCHI_CLOCK   *ic,
                         SetForbiddenEdges( pBNS, at, num_atoms, BNS_EDGE_FORBIDDEN_MASK, nebend, ebend );
 #endif
                         ret = BnsAdjustFlowBondsRad( pBNS, pBD, at, num_atoms );
+#ifdef FIX_AROM_RADICAL
+                        /* Issue #154: restoring the pre-search snapshot above
+                           re-installed the FIX_AROM_RADICAL-neutralized state
+                           (radical cleared, one implicit H added). Mirror the
+                           normal path's restoration (see the n_arom_radicals block
+                           earlier) so any stored aromatic doublet radical is put
+                           back into at[] for the output; otherwise a structure that
+                           has BOTH a neutralized aromatic radical and a charged
+                           electron source reaching this retry would lose the radical
+                           (mis-encoded as an extra implicit H). */
+                        if (stored_radicals)
+                        {
+                            for (i = 0; i < num_atoms; i++)
+                            {
+                                if (stored_radicals[i])
+                                {
+                                    at[i].radical = stored_radicals[i];
+                                    at[i].num_H--;
+                                }
+                            }
+                        }
+#endif
                     }
                     else
                     {

--- a/INCHI-1-TEST/tests/test_executable/test_aromatic_ions.py
+++ b/INCHI-1-TEST/tests/test_executable/test_aromatic_ions.py
@@ -241,13 +241,6 @@ M  END
 """
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="#154 (schatzsc on PR #234): the charged-ion relaxation acts on the specific "
-    "atom charged in the molfile, before InChI's mobile-charge normalization, so the "
-    "result is placement-dependent (and -9986s for most placements). A delocalized "
-    "anion must give one placement-independent InChI; needs the aromaticity rework.",
-)
 def test_MethylCyclopentadienyl_anion_charge_placement_invariance(run_inchi_exe):
     """All -1 placements on the methylcyclopentadienyl ring are the same molecule and
     must produce a single identical InChI (no hallucinated isomers, no -9986)."""

--- a/INCHI-1-TEST/tests/test_executable/test_aromatic_ions.py
+++ b/INCHI-1-TEST/tests/test_executable/test_aromatic_ions.py
@@ -206,13 +206,91 @@ M  END
 
 @pytest.mark.xfail(
     strict=True,
-    reason="#82: ferrocene Cp carbons have metal bonds; organometallic pi-coordination "
-    "is out of scope for the charged-pi-center fix and needs the aromaticity rework.",
+    reason="This heavy-atom fixture draws the Cp rings with NEUTRAL carbons, so no "
+    "aromatic electron source is present to relax and the kekulizer cannot resolve the "
+    "odd rings (fails in both default and -MolecularInorganics modes). A charge-explicit "
+    "ferrocene (Cp- rings) DOES kekulize under -MolecularInorganics -- see "
+    "test_Ferrocene_charged_molecular_inorganics.",
 )
 def test_Ferrocene_heavy_atoms(molfile_Ferrocene_heavy_atoms, run_inchi_exe):
     result = run_inchi_exe(molfile_Ferrocene_heavy_atoms)
 
     assert "Cannot process aromatic bonds" not in result.log
+
+
+# --- connected organometallic aromatics under -MolecularInorganics -----------
+# Metal stays bonded to the Cp rings (not disconnected); the aromatic ring atoms
+# are metal-bonded. The revert-to-flexible-bonds network rebuild relaxes the Cp-
+# charge centers and kekulizes the connected system in place. Refs #154, #82.
+
+def _molfile_metallocene_anion(metal, metal_chg):
+    """eta5 bis-cyclopentadienyl metal, aromatic (type-4) rings, two Cp- rings
+    (one -1 carbon each) coordinated to `metal` via type-9 bonds. `metal_chg` sets
+    the metal's formal charge (Fe: 0 -> net -2; Co: +1 -> net -1)."""
+    chg_line = f"M  V30 7 {metal} 20.4134 -20.7234 0 0 CHG={metal_chg} " if metal_chg \
+        else f"M  V30 7 {metal} 20.4134 -20.7234 0 0 "
+    return f"""
+  ACCLDraw
+
+  0  0  0     0  0            999 V3000
+M  V30 BEGIN CTAB
+M  V30 COUNTS 13 12 0 0 0
+M  V30 BEGIN ATOM
+M  V30 1 C 19.44 -22.4142 -0.1542 0
+M  V30 2 C 19.8251 -23.417 0.6958 0
+M  V30 3 C 21.204 -23.4477 0.7167 0
+M  V30 4 C 21.6716 -22.4638 -0.0917 0
+M  V30 5 C 20.5725 -21.854 -0.7083 0 CHG=-1
+M  V30 6 * 20.4688 -22.625 0 0
+{chg_line}
+M  V30 8 * 20.5 -19.1875 0 0
+M  V30 9 C 20.5767 -18.3331 -0.7083 0 CHG=-1
+M  V30 10 C 19.44 -18.8933 -0.1542 0
+M  V30 11 C 19.8251 -19.8962 0.6958 0
+M  V30 12 C 21.6716 -18.943 -0.0917 0
+M  V30 13 C 21.204 -19.9269 0.7167 0
+M  V30 END ATOM
+M  V30 BEGIN BOND
+M  V30 1 4 1 2
+M  V30 2 4 2 3
+M  V30 3 4 3 4
+M  V30 4 4 4 5
+M  V30 5 4 5 1
+M  V30 6 9 7 6 ENDPTS=(5 5 1 2 4 3) ATTACH=ALL
+M  V30 7 9 7 8 ENDPTS=(5 9 10 11 12 13) ATTACH=ALL
+M  V30 8 4 9 10
+M  V30 9 4 10 11
+M  V30 10 4 12 9
+M  V30 11 4 11 13
+M  V30 12 4 13 12
+M  V30 END BOND
+M  V30 END CTAB
+M  END
+"""
+
+
+# MolecularInorganics emits the non-standard "InChI=1B/" tag, which
+# parse_inchi_from_executable_output (regex InChI=1S?/) does not match, so these
+# assert the expected string is present in the raw output directly.
+
+def test_Ferrocene_charged_molecular_inorganics(run_inchi_exe):
+    result = run_inchi_exe(_molfile_metallocene_anion("Fe", 0), args="-MolecularInorganics")
+
+    assert "Cannot process aromatic bonds" not in result.log
+    assert (
+        "InChI=1B/C10H10Fe/c1-2-4-5-3(1)11(1,2,4,5)6-7(11)9(11)10(11)8(6)11/h1-10H/q-2"
+        in result.output
+    )
+
+
+def test_Cobaltocene_anion_molecular_inorganics(run_inchi_exe):
+    result = run_inchi_exe(_molfile_metallocene_anion("Co", 1), args="-MolecularInorganics")
+
+    assert "Cannot process aromatic bonds" not in result.log
+    assert (
+        "InChI=1B/C10H10Co/c1-3-7-8-4(1)11(3,7,8)5-2-6(11)10(11)9(5)11/h1-10H/q-1"
+        in result.output
+    )
 
 
 def _molfile_methyl_cyclopentadienyl_anion(charged_atom):

--- a/INCHI-1-TEST/tests/test_executable/test_aromatic_ions.py
+++ b/INCHI-1-TEST/tests/test_executable/test_aromatic_ions.py
@@ -65,32 +65,197 @@ M  END
 """
 
 
-@pytest.mark.xfail(strict=True, raises=AssertionError)
 def test_Cyclopentadiene_anion(molfile_Cyclopentadiene_anion, run_inchi_exe):
     result = run_inchi_exe(molfile_Cyclopentadiene_anion)
 
-    assert "Error -9986 (Cannot process aromatic bonds)" not in result.stderr
+    assert "Cannot process aromatic bonds" not in result.log
     assert "InChI=1S/C5H5/c1-2-4-5-3-1/h1-5H/q-1" == parse_inchi_from_executable_output(
         result.output
     )
 
 
-@pytest.mark.xfail(strict=True, raises=AssertionError)
 def test_Cycloheptatriene_cation(molfile_Cycloheptatriene_cation, run_inchi_exe):
     result = run_inchi_exe(molfile_Cycloheptatriene_cation)
 
-    assert "Error -9986 (Cannot process aromatic bonds)" not in result.stderr
+    assert "Cannot process aromatic bonds" not in result.log
     assert (
         "InChI=1S/C7H7/c1-2-4-6-7-5-3-1/h1-7H/q+1"
         == parse_inchi_from_executable_output(result.output)
     )
 
 
-@pytest.mark.xfail(strict=True, raises=AssertionError)
 def test_Cyclopropene_cation(molfile_Cyclopropene_cation, run_inchi_exe):
     result = run_inchi_exe(molfile_Cyclopropene_cation)
 
-    assert "Error -9986 (Cannot process aromatic bonds)" not in result.stderr
+    assert "Cannot process aromatic bonds" not in result.log
     assert "InChI=1S/C3H3/c1-2-3-1/h1-3H/q+1" == parse_inchi_from_executable_output(
         result.output
     )
+
+
+@pytest.fixture
+def molfile_Pyridinium():
+    return """
+  ChemDraw
+
+  6  6  0  0  0  0  0  0  0  0999 V2000
+   -0.7145    0.4125    0.0000 N   0  0  0  0  0  0  0  0  0  0  0  0
+   -0.7145   -0.4125    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    0.0000   -0.8250    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    0.7145   -0.4125    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    0.7145    0.4125    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    0.0000    0.8250    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+  1  2  4  0
+  2  3  4  0
+  3  4  4  0
+  4  5  4  0
+  5  6  4  0
+  6  1  4  0
+M  CHG  1   1   1
+M  END
+"""
+
+
+def test_Pyridinium_unchanged(molfile_Pyridinium, run_inchi_exe):
+    result = run_inchi_exe(molfile_Pyridinium)
+
+    assert "Cannot process aromatic bonds" not in result.log
+    assert "InChI=1S/C5H5N/c1-2-4-6-5-3-1/h1-5H/p+1" == parse_inchi_from_executable_output(
+        result.output
+    )
+
+
+@pytest.fixture
+def molfile_Cyclopentadienyl_radical():
+    return """
+  ChemDraw
+
+  5  5  0  0  0  0  0  0  0  0999 V2000
+   -0.6348    0.4125    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -0.6348   -0.4125    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    0.1498   -0.6674    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    0.6348    0.0000    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    0.1498    0.6674    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+  1  2  4  0
+  2  3  4  0
+  3  4  4  0
+  4  5  4  0
+  5  1  4  0
+M  RAD  1   1   2
+M  END
+"""
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="#154: a neutral aromatic radical (cyclopentadienyl radical) fails inside "
+    "the pre-existing FIX_AROM_RADICAL path, before the charged-ion relaxation runs. "
+    "Untangling radical handling is out of scope for the charged-ion fix and needs the "
+    "aromaticity rework.",
+)
+def test_Cyclopentadienyl_radical(molfile_Cyclopentadienyl_radical, run_inchi_exe):
+    result = run_inchi_exe(molfile_Cyclopentadienyl_radical)
+
+    assert "Cannot process aromatic bonds" not in result.log
+    inchi = parse_inchi_from_executable_output(result.output)
+    assert inchi == "InChI=1S/C5H5/c1-2-4-5-3-1/h1-5H"
+
+
+@pytest.fixture
+def molfile_Ferrocene_heavy_atoms():
+    # Two cyclopentadienyl rings (heavy atoms only) eta5-coordinated to Fe via
+    # type-9 (coordinative) bonds. Aromatic ring bonds are type 4.
+    return """
+  ChemDraw
+
+ 11 20  0  0  0  0  0  0  0  0999 V2000
+    0.0000    1.2000    0.0000 Fe  0  0  0  0  0  0  0  0  0  0  0  0
+   -0.9511    2.0000    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -0.5878    2.9000    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    0.5878    2.9000    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    0.9511    2.0000    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    0.0000    1.4000    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -0.9511    0.4000    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -0.5878   -0.5000    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    0.5878   -0.5000    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    0.9511    0.4000    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    0.0000    1.0000    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+  2  3  4  0
+  3  4  4  0
+  4  5  4  0
+  5  6  4  0
+  6  2  4  0
+  7  8  4  0
+  8  9  4  0
+  9 10  4  0
+ 10 11  4  0
+ 11  7  4  0
+  1  2  9  0
+  1  3  9  0
+  1  4  9  0
+  1  5  9  0
+  1  6  9  0
+  1  7  9  0
+  1  8  9  0
+  1  9  9  0
+  1 10  9  0
+  1 11  9  0
+M  END
+"""
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="#82: ferrocene Cp carbons have metal bonds; organometallic pi-coordination "
+    "is out of scope for the charged-pi-center fix and needs the aromaticity rework.",
+)
+def test_Ferrocene_heavy_atoms(molfile_Ferrocene_heavy_atoms, run_inchi_exe):
+    result = run_inchi_exe(molfile_Ferrocene_heavy_atoms)
+
+    assert "Cannot process aromatic bonds" not in result.log
+
+
+def _molfile_methyl_cyclopentadienyl_anion(charged_atom):
+    """Methylcyclopentadienyl anion [C5H4-CH3]- with the -1 formal charge placed on
+    ring atom `charged_atom` (1-5; atom 1 carries the methyl). Every placement denotes
+    the same delocalized anion, so all must yield one identical, placement-independent
+    InChI (schatzsc, PR #234)."""
+    return f"""
+  test
+
+  6  6  0  0  0  0  0  0  0  0999 V2000
+   -0.6348    0.4125    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -0.6348   -0.4125    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    0.1498   -0.6674    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    0.6348    0.0000    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    0.1498    0.6674    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -1.4200    0.8000    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+  1  2  4  0
+  2  3  4  0
+  3  4  4  0
+  4  5  4  0
+  5  1  4  0
+  1  6  1  0
+M  CHG  1   {charged_atom}  -1
+M  END
+"""
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="#154 (schatzsc on PR #234): the charged-ion relaxation acts on the specific "
+    "atom charged in the molfile, before InChI's mobile-charge normalization, so the "
+    "result is placement-dependent (and -9986s for most placements). A delocalized "
+    "anion must give one placement-independent InChI; needs the aromaticity rework.",
+)
+def test_MethylCyclopentadienyl_anion_charge_placement_invariance(run_inchi_exe):
+    """All -1 placements on the methylcyclopentadienyl ring are the same molecule and
+    must produce a single identical InChI (no hallucinated isomers, no -9986)."""
+    inchis = set()
+    for charged_atom in (1, 2, 3, 4, 5):
+        result = run_inchi_exe(_molfile_methyl_cyclopentadienyl_anion(charged_atom))
+        assert "Cannot process aromatic bonds" not in result.log, (
+            f"charge on ring atom {charged_atom} failed with -9986"
+        )
+        inchis.add(parse_inchi_from_executable_output(result.output))
+    assert len(inchis) == 1, f"charge placement changed the InChI: {sorted(inchis)}"

--- a/INCHI-1-TEST/tests/test_unit/test_aromaticity.cpp
+++ b/INCHI-1-TEST/tests/test_unit/test_aromaticity.cpp
@@ -260,3 +260,37 @@ TEST(test_aromaticity, replace_arom_bonds_resolves_when_reference_indexing_diffe
     FreeInpAtom(&at);
     FreeInpAtom(&at2);
 }
+
+// ---- huckel_pi_contribution ------------------------------------------------
+
+TEST(test_aromaticity, huckel_pi_contribution_cation_donates_zero)
+{
+    inp_ATOM a{};
+    a.elname[0] = 'C';
+    a.charge = 1;               // tropylium / cyclopropenyl carbon
+    EXPECT_EQ(huckel_pi_contribution(&a, 0), 0);
+}
+
+TEST(test_aromaticity, huckel_pi_contribution_anion_donates_two)
+{
+    inp_ATOM a{};
+    a.elname[0] = 'C';
+    a.charge = -1;              // cyclopentadienyl carbanion
+    EXPECT_EQ(huckel_pi_contribution(&a, 0), 2);
+}
+
+TEST(test_aromaticity, huckel_pi_contribution_radical_donates_one)
+{
+    inp_ATOM a{};
+    a.elname[0] = 'C';
+    a.charge = 0;
+    a.radical = RADICAL_DOUBLET; // cyclopentadienyl radical center (SOMO)
+    EXPECT_EQ(huckel_pi_contribution(&a, 0), 1);
+}
+
+TEST(test_aromaticity, huckel_pi_contribution_ordinary_carbon_donates_one)
+{
+    inp_ATOM a{};
+    a.elname[0] = 'C';           // neutral non-radical: one ring double bond
+    EXPECT_EQ(huckel_pi_contribution(&a, 0), 1);
+}

--- a/INCHI-1-TEST/tests/test_unit/test_aromaticity.cpp
+++ b/INCHI-1-TEST/tests/test_unit/test_aromaticity.cpp
@@ -329,6 +329,7 @@ TEST(test_aromaticity, electron_source_false_for_neutral_CH)
 // Ring coordination = 3 - 1 metal = 2 -> still a source.
 TEST(test_aromaticity, electron_source_true_for_metal_bonded_anion_carbon)
 {
+    const U_CHAR EL_NUMBER_FE = 26; /* iron atomic number; no EL_NUMBER_FE in util.h */
     inp_ATOM a[4]{};
     a[0].el_number = EL_NUMBER_C;
     a[0].valence = 3;                 // 2 ring + 1 metal
@@ -340,7 +341,7 @@ TEST(test_aromaticity, electron_source_true_for_metal_bonded_anion_carbon)
     a[0].chem_bonds_valence = 4;      // > valence
     a[1].el_number = EL_NUMBER_C;
     a[2].el_number = EL_NUMBER_C;
-    a[3].el_number = ((U_CHAR)26);    // Fe (atomic number 26) -- metal neighbor
+    a[3].el_number = EL_NUMBER_FE;    // Fe (atomic number 26) -- metal neighbor
     EXPECT_EQ(is_aromatic_electron_source(a, 0), 1);
 }
 

--- a/INCHI-1-TEST/tests/test_unit/test_aromaticity.cpp
+++ b/INCHI-1-TEST/tests/test_unit/test_aromaticity.cpp
@@ -294,3 +294,67 @@ TEST(test_aromaticity, huckel_pi_contribution_ordinary_carbon_donates_one)
     a.elname[0] = 'C';           // neutral non-radical: one ring double bond
     EXPECT_EQ(huckel_pi_contribution(&a, 0), 1);
 }
+
+// ---- is_aromatic_electron_source -------------------------------------------
+
+// Cyclopentadienyl-anion carbon: 2 ring neighbors, -1, spare valence, no H.
+TEST(test_aromaticity, electron_source_true_for_anion_ring_carbon)
+{
+    inp_ATOM a[2]{};
+    a[0].el_number = EL_NUMBER_C;
+    a[0].valence = 2;                 // two ring neighbors
+    a[0].neighbor[0] = 1; a[0].neighbor[1] = 1;
+    a[0].chem_bonds_valence = 3;      // > valence: spare from the aromatic system
+    a[0].num_H = 0;
+    a[0].charge = -1;
+    a[1].el_number = EL_NUMBER_C;     // a neighbor (non-metal)
+    EXPECT_EQ(is_aromatic_electron_source(a, 0), 1);
+}
+
+// Ordinary aromatic CH (pyridine-like ring carbon): neutral, has H -> not a source.
+TEST(test_aromaticity, electron_source_false_for_neutral_CH)
+{
+    inp_ATOM a[2]{};
+    a[0].el_number = EL_NUMBER_C;
+    a[0].valence = 2;
+    a[0].neighbor[0] = 1; a[0].neighbor[1] = 1;
+    a[0].chem_bonds_valence = 3;
+    a[0].num_H = 1;                   // implicit H present
+    a[0].charge = 0;
+    a[1].el_number = EL_NUMBER_C;
+    EXPECT_EQ(is_aromatic_electron_source(a, 0), 0);
+}
+
+// Metal-bonded Cp-anion carbon (connected ferrocene): 3 neighbors incl. Fe.
+// Ring coordination = 3 - 1 metal = 2 -> still a source.
+TEST(test_aromaticity, electron_source_true_for_metal_bonded_anion_carbon)
+{
+    inp_ATOM a[4]{};
+    a[0].el_number = EL_NUMBER_C;
+    a[0].valence = 3;                 // 2 ring + 1 metal
+    a[0].neighbor[0] = 1;             // ring C
+    a[0].neighbor[1] = 2;             // ring C
+    a[0].neighbor[2] = 3;             // Fe metal neighbor
+    a[0].charge = -1;
+    a[0].num_H = 0;
+    a[0].chem_bonds_valence = 4;      // > valence
+    a[1].el_number = EL_NUMBER_C;
+    a[2].el_number = EL_NUMBER_C;
+    a[3].el_number = ((U_CHAR)26);    // Fe (atomic number 26) -- metal neighbor
+    EXPECT_EQ(is_aromatic_electron_source(a, 0), 1);
+}
+
+// Doublet radical carbon (Cp radical center): neutral radical, spare valence.
+TEST(test_aromaticity, electron_source_true_for_radical_carbon)
+{
+    inp_ATOM a[2]{};
+    a[0].el_number = EL_NUMBER_C;
+    a[0].valence = 2;
+    a[0].neighbor[0] = 1; a[0].neighbor[1] = 1;
+    a[0].chem_bonds_valence = 3;
+    a[0].num_H = 0;
+    a[0].charge = 0;
+    a[0].radical = RADICAL_DOUBLET;
+    a[1].el_number = EL_NUMBER_C;
+    EXPECT_EQ(is_aromatic_electron_source(a, 0), 1);
+}

--- a/INCHI-1-TEST/tests/test_unit/test_aromaticity.cpp
+++ b/INCHI-1-TEST/tests/test_unit/test_aromaticity.cpp
@@ -358,3 +358,37 @@ TEST(test_aromaticity, electron_source_true_for_radical_carbon)
     a[1].el_number = EL_NUMBER_C;
     EXPECT_EQ(is_aromatic_electron_source(a, 0), 1);
 }
+
+// ---- relax_aromatic_electron_sources ---------------------------------------
+
+TEST(test_aromaticity, relax_moves_valence_unit_to_H_on_source)
+{
+    inp_ATOM a[2]{};
+    a[0].el_number = EL_NUMBER_C;
+    a[0].valence = 2;
+    a[0].neighbor[0] = 1; a[0].neighbor[1] = 1;
+    a[0].chem_bonds_valence = 3;
+    a[0].num_H = 0;
+    a[0].charge = -1;
+    a[1].el_number = EL_NUMBER_C;
+
+    EXPECT_EQ(relax_aromatic_electron_sources(a, 2), 1);
+    EXPECT_EQ(a[0].chem_bonds_valence, 2); // decremented
+    EXPECT_EQ(a[0].num_H, 1);              // incremented
+    EXPECT_EQ(a[0].charge, -1);            // charge untouched
+}
+
+TEST(test_aromaticity, relax_leaves_non_sources_untouched)
+{
+    inp_ATOM a[2]{};
+    a[0].el_number = EL_NUMBER_C;          // ordinary CH: has H -> not a source
+    a[0].valence = 2;
+    a[0].neighbor[0] = 1; a[0].neighbor[1] = 1;
+    a[0].chem_bonds_valence = 3;
+    a[0].num_H = 1;
+    a[1].el_number = EL_NUMBER_C;
+
+    EXPECT_EQ(relax_aromatic_electron_sources(a, 2), 0);
+    EXPECT_EQ(a[0].chem_bonds_valence, 3); // unchanged
+    EXPECT_EQ(a[0].num_H, 1);
+}


### PR DESCRIPTION
Stacked on #239 (base branch `extract-aromaticity-utils`, which adds the `aromaticity.{c,h}` module this builds on). GitHub will retarget this to `dev` automatically once #239 merges. Supersedes #234; refs #154, #82.

## What this does

Aromatic systems that previously failed with `Error -9986 (Cannot process aromatic bonds)` now kekulize into valid InChIs. InChI has no "aromatic" bond order — type-4 bonds are kekulized into localized single/double bonds by a balanced-network search that needs a perfect double-bond matching. Odd rings whose charge/radical center contributes an empty orbital, lone pair, or single electron (not a double bond) have no such matching and fail.

The fix adds a Hückel-informed relaxation on the **failure path only**, then rebuilds the network from the original flexible bonds and retries once:

1. A self-contained classifier in `aromaticity.{c,h}` — `is_aromatic_electron_source` (a ring atom that can't take a double bond: ring-coordination 2 excluding metal bonds, spare valence, charged or doublet-radical) and `relax_aromatic_electron_sources` (moves one valence unit to an implicit H). Fully unit-tested; no `BN_STRUCT` dependency.
2. In `mark_alt_bonds_and_taut_groups` (`ichi_bns.c`), on `BNS_ALTBOND_ERR`: restore a pre-search snapshot (flexible type-4 `BOND_ALTERN` bonds + original valences), relax the electron sources, tear down and rebuild the network from a fresh `AllocateAndInitBnStruct` (so vertex capacities re-derive from the relaxed atoms), and retry the conversion once. Restoring the flexible bonds lets the search itself find the matching — so charge *position* stops mattering and metal-bonded rings resolve in place.

Because it runs only after the first kekulization already errored, every structure that kekulized before is byte-identical.

## Now processes correctly

| Structure | Result |
|---|---|
| Cyclopropenyl cation (C₃H₃⁺) | `InChI=1S/C3H3/c1-2-3-1/h1-3H/q+1` |
| Cyclopentadienyl anion (C₅H₅⁻) | `InChI=1S/C5H5/c1-2-4-5-3-1/h1-5H/q-1` |
| Tropylium cation (C₇H₇⁺) | `InChI=1S/C7H7/c1-2-4-6-7-5-3-1/h1-7H/q+1` |
| Methyl-cyclopentadienyl anion — **all 5 ring −1 placements** | one identical `InChI=1S/C6H7/c1-6-4-2-3-5-6/h2-5H,1H3/q-1` (charge-placement invariance) |
| Ferrocene (connected, `-MolecularInorganics`) | `InChI=1B/C10H10Fe/…/q-2` |
| Cobaltocene anion (connected, `-MolecularInorganics`) | `InChI=1B/C10H10Co/…/q-1` |
| Pyridinium (control) | unchanged — 3-coordinate N⁺ correctly not relaxed |

## Deferred (strict `xfail`, flip loudly when fixed)

- Neutral cyclopentadienyl radical — fails upstream in the pre-existing `FIX_AROM_RADICAL` path, before this hook.
- Default-mode (disconnected) organometallics — a distinct failure in the metal-disconnection path; the connected `-MolecularInorganics` path is the one addressed here.
- Neutral-drawn metallocene rings — no ring charge to relax (chemically under-specified; the charge-explicit drawing works).

## Verification

- Clean full build (CLI + libinchi).
- C++ unit tests: 17/17 suites (22 `test_aromaticity` cases).
- Executable pytest: `test_aromatic_ions.py` 7 passed / 2 xfailed; full suite 19 passed / 3 skipped / 9 xfailed, no failures.
- **Regression suite (config_ci, 4190 structures): 0 diffs.**
- Multithreading: clean.

**Guarantee:** no regression on any structure that already produced an InChI; new InChIs appear only for inputs that previously errored with -9986. The one-shot retry either produces a valid kekulization or preserves the original error.

## Relationship to #234

Supersedes #234 (`fix/aromatic-ion-valence`), whose charge-center relaxation was the starting point; its `test_aromatic_ions.py` cases are carried over here. #234 can be closed in favor of this.
