### PR TITLE
fix: reject non-positive mobile-H atom indexes in ParseSegmentMobileH

### DIFF
--- a/INCHI-1-SRC/INCHI_BASE/src/ichiread.c
+++ b/INCHI-1-SRC/INCHI_BASE/src/ichiread.c
@@ -8499,7 +8499,8 @@ int ParseSegmentMobileH(const char* str,
                         p = q;
                     }
                 }
-                if (curAtom > nxtAtom || nxtAtom > numCtAtoms || p > pTaut)
+                if (curAtom <= 0 || curAtom > nxtAtom ||
+                    nxtAtom > numCtAtoms || p > pTaut)
                 {
                     ret = RI_ERR_SYNTAX; /* syntax error */
                     goto exit_function;
@@ -8612,7 +8613,7 @@ int ParseSegmentMobileH(const char* str,
 #endif
                     }
                     /* consitency check */
-                    if (!curAtom || curAtom > numCtAtoms ||
+                    if (curAtom <= 0 || curAtom > numCtAtoms ||
                         nxtAtom < curAtom || nxtAtom > numCtAtoms)
                     {
                         ret = RI_ERR_SYNTAX; /* syntax error */

--- a/INCHI-1-TEST/tests/test_unit/test_github_249.cpp
+++ b/INCHI-1-TEST/tests/test_unit/test_github_249.cpp
@@ -1,0 +1,19 @@
+#include <gtest/gtest.h>
+
+extern "C"
+{
+#include "../../../INCHI-1-SRC/INCHI_BASE/src/inchi_api.h"
+}
+
+TEST(test_github_249, rejects_out_of_range_mobile_h_atom_number)
+{
+    char input[] = "InChI=1/H/h4294967295H";
+    inchi_InputINCHI request = {};
+    inchi_Output response = {};
+
+    request.szInChI = input;
+
+    EXPECT_EQ(GetINCHIfromINCHI(&request, &response), inchi_Ret_ERROR);
+
+    FreeINCHI(&response);
+}


### PR DESCRIPTION
<!--
Thank you for contributing to InChI!

PR titles MUST follow Conventional Commits — release-please uses them
to drive versioning and the CHANGELOG. Examples:
  feat: add support for new polymer normalization
  fix: NULL deref in ichister.c when stereo center has no neighbors
  feat!: change default behavior of metal implicit-H handling  (the `!` marks a breaking change)

For more details see:
  https://github.com/googleapis/release-please
  https://www.conventionalcommits.org/en/v1.0.0/

Allowed types: feat, fix, perf, revert, build, chore, ci, docs, refactor,
                style, test

Do NOT embed phase or task numbers in the type/scope
(write `feat: ...`, not `feat(05-04): ...`).
-->

## Summary

- Reject non-positive mobile-H atom indexes in both affected `ParseSegmentMobileH()` parsing branches before indexing `nNum_H`.
- Add a classic `libinchi` API regression test for the malformed input reported in #249.
- Return `inchi_Ret_ERROR` for the invalid atom number instead of corrupting heap memory.

## Type of change

- [ ] feat — new feature (minor bump)
- [x] fix — bug fix (patch bump)
- [ ] perf — performance improvement (patch bump)
- [ ] BREAKING CHANGE — incompatible change (`!` in title or footer; major bump)
- [ ] refactor / docs / chore / build / ci / test (no release)

## Testing

- `./INCHI-1-TEST/build_with_cmake.sh all` completed successfully with GCC 11.4.0.
- All 17 unit-test executables passed with `ctest --output-on-failure`.
- `test_github_249` passed in a GCC Debug/AddressSanitizer build.
- `test_github_249` passed in a Clang 15.0.7 Release build.
- The executable test suite completed with 15 passed, 3 skipped, and 10 expected xfails.
- As a negative control, `test_github_249` aborts with `double free or corruption (out)` when the two bounds-check changes are removed.

## Checklist

- [x] PR title follows Conventional Commits
- [x] Builds cleanly for both targets (`./INCHI-1-TEST/build_with_cmake.sh all`)
- [x] Compiles without new warnings on GCC/Clang/MSVC where applicable (tested with GCC 11.4.0 and Clang 15.0.7; MSVC was not available)
- [x] Code follows `.editorconfig` (4-space indent, LF, no trailing whitespace)
- [x] Unit tests pass (`ctest` in the `full_build` test directory)
- [x] CLI tests pass (`pytest INCHI-1-TEST/tests/test_executable`)
- [x] New behavior is covered by tests
- [x] Public API / behavior changes are documented (not applicable; this only rejects malformed input)

## Related issues

Closes #249
