### PR TITLE
fix: reject negative proton isotope indexes

### DIFF
--- a/INCHI-1-SRC/INCHI_BASE/src/ichi_bns.c
+++ b/INCHI-1-SRC/INCHI_BASE/src/ichi_bns.c
@@ -5970,9 +5970,9 @@ exit_function:
         if (at[0].iso_atw_diff) 
         {
 #if ( FIX_CURE53_ISSUE_NULL_DEREFERENCE_MAKE_A_COPY_OF_T_GROUP_INFO==1 || defined(FIX_IMPOSSIBLE_H_ISOTOPE_BUG) )
-            if (at[0].iso_atw_diff <= NUM_H_ISOTOPES)
+            if (0 < at[0].iso_atw_diff &&
+                at[0].iso_atw_diff <= NUM_H_ISOTOPES)
             {
-                /* djb-rwth: possible false positive oss-fuzz issue #39064660 */
                 t_group_info->tni.nNumRemovedProtonsIsotopic[at[0].iso_atw_diff - 1] ++;
             }
 #else

--- a/INCHI-1-TEST/tests/test_unit/test_inchi_dll_b.cpp
+++ b/INCHI-1-TEST/tests/test_unit/test_inchi_dll_b.cpp
@@ -56,3 +56,16 @@ TEST(test_inchi_dll_b, test_MakeINCHIFromMolfileText)
 
     FreeINCHI(poutput);
 }
+
+TEST(test_inchi_dll_b, test_GetStructFromINCHI_rejects_negative_isotope_mass)
+{
+    char inchi[] = "InChI=1/T/q+1/i12-112T";
+    inchi_InputINCHI input = {};
+    input.szInChI = inchi;
+    inchi_OutputStruct output = {};
+
+    EXPECT_EQ(GetStructFromINCHI(&input, &output), inchi_Ret_ERROR);
+    EXPECT_EQ(output.num_atoms, 0);
+
+    FreeStructFromINCHI(&output);
+}


### PR DESCRIPTION
## Summary

- prevent a negative proton isotope delta from indexing before
  `nNumRemovedProtonsIsotopic`
- add a `GetStructFromINCHI()` regression for public OSS-Fuzz issue
  488729177

## Root cause

The single-proton cleanup path checked only that `iso_atw_diff` was no larger
than `NUM_H_ISOTOPES`. Because the field is signed, the malformed input
`InChI=1/T/q+1/i12-112T` produced `iso_atw_diff == -112`, passed that upper
bound, and accessed the three-element array at index `-113`.

The public testcase reproduces on current `dev` as an ASan two-byte stack
out-of-bounds read in `mark_alt_bonds_and_taut_groups()`. Requiring a positive
delta before subtracting one makes the API reject the malformed string with
its normal `inchi_Ret_ERROR` result.

## Verification

- exact OSS-Fuzz testcase: ASan/UBSan failure before the patch, clean rejection
  after the patch
- focused API regression passes under ASan
- all 17 C++ unit-test executables pass under ASan
- CLI suite: 15 passed, 3 skipped, 10 xfailed
- both CLI and `libinchi` targets build successfully
- `git diff --check` passes

## Type of change

- [ ] feat - new feature (minor bump)
- [x] fix - bug fix (patch bump)
- [ ] perf - performance improvement (patch bump)
- [ ] BREAKING CHANGE - incompatible change
- [ ] refactor / docs / chore / build / ci / test (no release)

## Checklist

- [x] PR title follows Conventional Commits
- [x] Builds cleanly for both targets (`./INCHI-1-TEST/build_with_cmake.sh all`)
- [ ] Compiles without new warnings on GCC/Clang/MSVC where applicable
- [x] Code follows `.editorconfig` (4-space indent, LF, no trailing whitespace)
- [x] Unit tests pass (`ctest` in the `full_build` test dir)
- [x] CLI tests pass (`pytest INCHI-1-TEST/tests/test_executable`)
- [x] New behavior is covered by tests
- [x] Public API / behavior changes are documented (not applicable)

## Related issues

Refs #209 (GOF #488729177 only; the issue also tracks two unrelated leaks).
