### PR TITLE
build: add install targets

### DIFF
--- a/INCHI-1-SRC/INCHI_API/demos/inchi_main/src/CMakeLists.txt
+++ b/INCHI-1-SRC/INCHI_API/demos/inchi_main/src/CMakeLists.txt
@@ -112,4 +112,5 @@ else()
 	)
 endif()
 
+install(FILES "${PROJECT_BINARY_DIR}/inchi_version_rc.h" DESTINATION include/inchi)
 install(TARGETS inchi_main)

--- a/INCHI-1-SRC/INCHI_API/demos/inchi_main/src/CMakeLists.txt
+++ b/INCHI-1-SRC/INCHI_API/demos/inchi_main/src/CMakeLists.txt
@@ -111,3 +111,5 @@ else()
 		COMMAND_EXPAND_LISTS
 	)
 endif()
+
+install(TARGETS inchi_main)

--- a/INCHI-1-SRC/INCHI_API/libinchi/src/CMakeLists.txt
+++ b/INCHI-1-SRC/INCHI_API/libinchi/src/CMakeLists.txt
@@ -201,6 +201,7 @@ elseif(WIN32 AND NOT MSVC)
 endif()
 
 install(FILES
+	"${PROJECT_BINARY_DIR}/inchi_version_rc.h"
 	"${P_BASE}/bcf_s.h"
 	"${P_BASE}/ichisize.h"
 	"${P_BASE}/inchi_api.h"

--- a/INCHI-1-SRC/INCHI_API/libinchi/src/CMakeLists.txt
+++ b/INCHI-1-SRC/INCHI_API/libinchi/src/CMakeLists.txt
@@ -199,3 +199,11 @@ if(UNIX AND NOT APPLE)
 elseif(WIN32 AND NOT MSVC)
 	target_link_options(libinchi PRIVATE "LINKER:--version-script=${P_LIBINCHI_MAP}/libinchi.map")
 endif()
+
+install(FILES
+	"${P_BASE}/bcf_s.h"
+	"${P_BASE}/ichisize.h"
+	"${P_BASE}/inchi_api.h"
+	"${P_BASE}/ixa.h"
+	DESTINATION include/inchi)
+install(TARGETS libinchi)

--- a/INCHI-1-SRC/INCHI_EXE/inchi-1/src/CMakeLists.txt
+++ b/INCHI-1-SRC/INCHI_EXE/inchi-1/src/CMakeLists.txt
@@ -159,4 +159,5 @@ target_include_directories(inchi-1 PUBLIC
 string(REGEX REPLACE "/RTC(su|[1su])" "" CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG}")
 string(REGEX REPLACE "/RTC(su|[1su])" "" CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG}")
 
+install(FILES "${PROJECT_BINARY_DIR}/inchi_version_rc.h" DESTINATION include/inchi)
 install(TARGETS inchi-1)

--- a/INCHI-1-SRC/INCHI_EXE/inchi-1/src/CMakeLists.txt
+++ b/INCHI-1-SRC/INCHI_EXE/inchi-1/src/CMakeLists.txt
@@ -158,3 +158,5 @@ target_include_directories(inchi-1 PUBLIC
 
 string(REGEX REPLACE "/RTC(su|[1su])" "" CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG}")
 string(REGEX REPLACE "/RTC(su|[1su])" "" CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG}")
+
+install(TARGETS inchi-1)


### PR DESCRIPTION
<!--
Thank you for contributing to InChI!

PR titles MUST follow Conventional Commits — release-please uses them
to drive versioning and the CHANGELOG. Examples:
  feat: add support for new polymer normalization
  fix: NULL deref in ichister.c when stereo center has no neighbors
  feat!: change default behavior of metal implicit-H handling  (the `!` marks a breaking change)

For more details see:
  https://github.com/googleapis/release-please
  https://www.conventionalcommits.org/en/v1.0.0/

Allowed types: feat, fix, perf, revert, build, chore, ci, docs, refactor,
                style, test

Do NOT embed phase or task numbers in the type/scope
(write `feat: ...`, not `feat(05-04): ...`).
-->

## Summary

This enables a user to install binaries, headers, and a library to system.

## Type of change

- [ ] feat — new feature (minor bump)
- [ ] fix — bug fix (patch bump)
- [ ] perf — performance improvement (patch bump)
- [ ] BREAKING CHANGE — incompatible change (`!` in title or footer; major bump)
- [x] refactor / docs / chore / build / ci / test (no release)

## Checklist

- [x] PR title follows Conventional Commits
- [x] Builds cleanly for both targets (`./INCHI-1-TEST/build_with_cmake.sh all`)
- [x] Compiles without new warnings on GCC/Clang/MSVC where applicable
- [x] Code follows `.editorconfig` (4-space indent, LF, no trailing whitespace)
- [x] Unit tests pass (`ctest` in the `full_build` test dir)
- [x] CLI tests pass (`pytest INCHI-1-TEST/tests/test_executable`) ~~no, I am using python3.14 on my machine and maturin fails~~ fixed by #262
- [ ] New behavior is covered by tests
- [ ] Public API / behavior changes are documented (Doxygen in headers + README/docs if applicable)

## Related issues

<!-- Closes #123, refs #456, etc. -->
