### PR TITLE
test: support python 3.13 and later, and fix pydantic dependency

### DIFF
--- a/INCHI-1-TEST/pyproject.toml
+++ b/INCHI-1-TEST/pyproject.toml
@@ -1,8 +1,12 @@
 [project]
 name = "inchi_tests"
 version = "1.0.0"
-requires-python = ">=3.11,<3.13"
-dependencies = ["pydantic == 2.11.5", "pytest == 9.0.3"]
+requires-python = ">=3.11"
+dependencies = [
+    "pydantic == 2.11.5; python_version <  '3.14'",
+    "pydantic >= 2.12.0; python_version >= '3.14'",
+    "pytest == 9.0.3",
+]
 
 [tool.setuptools.packages.find]
 where = ["src", "tests/test_library"]


### PR DESCRIPTION


<!--
Thank you for contributing to InChI!

PR titles MUST follow Conventional Commits — release-please uses them
to drive versioning and the CHANGELOG. Examples:
  feat: add support for new polymer normalization
  fix: NULL deref in ichister.c when stereo center has no neighbors
  feat!: change default behavior of metal implicit-H handling  (the `!` marks a breaking change)

For more details see:
  https://github.com/googleapis/release-please
  https://www.conventionalcommits.org/en/v1.0.0/

Allowed types: feat, fix, perf, revert, build, chore, ci, docs, refactor,
                style, test

Do NOT embed phase or task numbers in the type/scope
(write `feat: ...`, not `feat(05-04): ...`).
-->

## Summary

Bump python upper bound since RDKit is no longer in use (#240). Also, python3.14 requires pydantic>=2.12.0.

## Type of change

- [ ] feat — new feature (minor bump)
- [ ] fix — bug fix (patch bump)
- [ ] perf — performance improvement (patch bump)
- [ ] BREAKING CHANGE — incompatible change (`!` in title or footer; major bump)
- [x] refactor / docs / chore / build / ci / test (no release)

## Checklist

- [x] PR title follows Conventional Commits
- [x] Builds cleanly for both targets (`./INCHI-1-TEST/build_with_cmake.sh all`)
- [x] Compiles without new warnings on GCC/Clang/MSVC where applicable
- [x] Code follows `.editorconfig` (4-space indent, LF, no trailing whitespace)
- [x] Unit tests pass (`ctest` in the `full_build` test dir)
- [x] CLI tests pass (`pytest INCHI-1-TEST/tests/test_executable`)
- [x] New behavior is covered by tests
- [ ] Public API / behavior changes are documented (Doxygen in headers + README/docs if applicable)

## Related issues

<!-- Closes #123, refs #456, etc. -->
#240